### PR TITLE
feat: add mix format to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,16 @@ repos:
     -   id: go-vet
         exclude: ^internal/(e2e|lint)/
 
+# Elixir formatting — mirrors CI `mix format --check-formatted`
+-   repo: local
+    hooks:
+    -   id: mix-format
+        name: mix-format
+        entry: mix format --check-formatted
+        language: system
+        files: \.exs?$
+        pass_filenames: false
+
 # Elixir model ID validation — prevents stale/deprecated model IDs
 -   repo: local
     hooks:


### PR DESCRIPTION
## Why This Matters

Elixir formatter was missing from pre-commit hooks, causing formatting-only fixup commits after CI failures on PRs #245 and #248. The Go side has `go-fmt` in pre-commit; the Elixir side had nothing. This adds parity and eliminates wasted CI round-trips.

Closes #259

## Trade-offs / Risks

- **Check-only, not auto-fix**: `--check-formatted` rejects but doesn't rewrite. Developers must run `mix format` manually. This is intentional per issue boundaries — auto-fix on commit can mask awareness of formatting conventions.
- **Requires local Elixir**: Hook uses `language: system`, so `mix` must be on PATH. Same requirement as `validate-elixir-models` hook already in the config.

## Intent Reference

> Elixir files are auto-checked by the formatter before every commit. No more formatting-only fixup commits.

Source: [#259](https://github.com/misty-step/thinktank/issues/259)

## Changes

- `.pre-commit-config.yaml`: Added `mix-format` local hook (check-only, `.exs?$` files)

## Alternatives Considered

1. **Do nothing**: Continue with CI-only enforcement. Rejected — wastes agent time on formatting round-trips.
2. **Auto-fix on commit** (`mix format` without `--check-formatted`): Rejected per issue boundaries — masks formatting awareness.
3. **Use a third-party pre-commit repo**: No canonical Elixir pre-commit repo exists; `language: system` is the standard approach.

## Acceptance Criteria

- [x] `pre-commit run mix-format --all-files` exits 0 on a formatted codebase
- [x] Committing an unformatted `.ex` or `.exs` file is rejected locally before push
- [x] CI `mix format --check-formatted` step still passes (defense in depth — unchanged)

## Manual QA

```bash
# Verify hook passes on clean codebase
pre-commit run mix-format --all-files
# Expected: exit 0, "Passed"

# Verify hook rejects unformatted code
echo 'defmodule   Ugly do\ndef    foo(  x   ), do:     x+1\nend' > /tmp/ugly.exs
cp /tmp/ugly.exs lib/ugly.exs
git add lib/ugly.exs .pre-commit-config.yaml
pre-commit run mix-format
# Expected: exit 1, shows formatting diff
```

## What Changed

```mermaid
graph LR
    A[git commit] --> B[gitleaks]
    B --> C[trailing-whitespace]
    C --> D[go-fmt / go-vet]
    D --> E[validate-elixir-models]
    E --> F[commit created]
```

```mermaid
graph LR
    A[git commit] --> B[gitleaks]
    B --> C[trailing-whitespace]
    C --> D[go-fmt / go-vet]
    D --> E["mix-format ✨"]
    E --> F[validate-elixir-models]
    F --> G[commit created]
```

The new hook runs between Go checks and Elixir model validation, catching formatting issues before they reach CI.

## Test Coverage

No test files — this is infrastructure config. Verified manually via `pre-commit run` with both formatted and unformatted inputs. CI `mix format --check-formatted` provides defense-in-depth.

## Merge Confidence

**High**. Single-file, 10-line addition. All existing hooks still pass. Mirrors an existing CI step locally. No behavioral change to the build or application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
