### PR TITLE
docs: rewrite CLAUDE.md for Elixir-primary codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,14 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-- `cmd/thinktank/`: CLI entrypoint and wiring.
-- `internal/`: core logic (models, file filtering, logging, processing).
-- `docs/`: design notes, ADRs, guides.
-- `scripts/`: dev tooling (coverage, pre-commit helpers).
-- `config/`, `build/`, `docker/`, `benchmarks/`, `reports/`: support assets and automation.
-- Tests live beside code as `*_test.go`.
+See [CLAUDE.md](CLAUDE.md) for architecture, commands, and conventions.
 
-## Build, Test, and Development Commands
-- `go build ./...`: build all packages.
-- `go test ./...`: run unit tests.
-- `go test -race ./...`: race check (required before commit).
-- `golangci-lint run ./...`: lint (fix all violations).
-- `./scripts/check-coverage.sh`: enforce 79% minimum coverage.
-- `./scripts/check-package-coverage.sh`: per-package coverage drilldown.
-- `./scripts/test-local.sh`: full local test run.
-- `govulncheck -scan=module`: vulnerability scan (hard fail).
-- `pre-commit install`: enable hooks (timeouts enforced).
+## Elixir Style
+- `mix format` output only
+- Pattern match over conditionals; `with` chains for multi-step error handling
+- Prefer deep modules with small public APIs
+- Tests live beside code as `*_test.exs` under `test/`
+- Table-driven tests via `for` comprehensions
 
-## Coding Style & Naming Conventions
-- Go idioms. `gofmt` output only; tabs for indent.
-- Names: `PascalCase` exported, `camelCase` unexported, files `lower_snake.go`.
-- Prefer deep modules, small interfaces. Extract pure logic from I/O.
-- No error suppression with `_`. Fix lint issues.
-- Logging: console-friendly output + structured JSON (see `internal/logutil`).
-
-## Testing Guidelines
-- TDD first. Table-driven tests for pure functions.
-- Prefer direct function testing with dependency injection. Avoid subprocess tests.
-- Use `setupTestEnvironment()`; save/restore env vars.
-- Integration tests skip when `OPENROUTER_API_KEY` missing:
-  `t.Skip("OPENROUTER_API_KEY not set")`.
-- Coverage target: 79% minimum via `./scripts/check-coverage.sh`.
-
-## Commit & Pull Request Guidelines
-- Conventional Commits required (`feat:`, `fix:`, `docs:`, `chore:`).
-- Keep PRs small, focused. Include:
-  - intent summary
-  - tests run (commands)
-  - linked issue or context
-- Update docs with code changes.
-
-## Security & Configuration Notes
-- No secrets in repo. Use env vars only (`OPENROUTER_API_KEY`).
-- Run `govulncheck` before release-quality changes.
+## Commit & PR
+- Conventional Commits required (`feat:`, `fix:`, `docs:`, `chore:`)
+- No secrets in repo — use env vars only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,9 @@ mix escript.build
 # Test
 mix test
 
-# Format (required before push)
-mix format
-mix format --check-formatted
+# Format: auto-fix locally, check in CI
+mix format                    # Apply formatting
+mix format --check-formatted  # Verify (CI gate)
 
 # Compile with warnings-as-errors
 mix compile --warnings-as-errors
@@ -73,13 +73,14 @@ govulncheck -scan=module
 - **Default models live in** `lib/thinktank/cli.ex` `@default_models`
 - **Go registry**: `internal/models/models.go` — legacy source of truth until #250 archives Go
 - **Pre-commit hook**: `scripts/validate-elixir-models.sh` rejects Elixir commits with model IDs not in Go registry
-- **If models are stale**: WebSearch OpenRouter models page, update both, then use the ID
+- **If models are stale**: WebSearch OpenRouter models page, update `lib/thinktank/cli.ex` and `internal/models/models.go`, then use the ID
 
 ### Pre-commit Hooks
 ```bash
 pre-commit install  # One-time setup
 ```
-Hooks: gitleaks, trailing-whitespace, go-fmt, go-vet, mix-format, validate-elixir-models.
+Hooks: gitleaks, trailing-whitespace, mix-format, validate-elixir-models.
+Legacy (until #250): go-fmt, go-vet.
 
 ## References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,88 +2,89 @@
 
 ## Purpose
 
-CLI tool that analyzes codebases using multiple LLMs via OpenRouter. Sends instructions + code to models, saves responses, optionally synthesizes.
+Agent-first research tool for multi-perspective AI analysis. Routes questions through an LLM-powered perspective router, dispatches agents in quick (parallel API) or deep (Pi subprocess) mode, produces kill-safe structured artifacts.
 
 ## Architecture Map
 
 ```
-cmd/thinktank/main.go          → CLI entry, flag parsing
-internal/cli/run.go:50         → Run() orchestrates execution
-internal/thinktank/            → Core processing logic
-  orchestrator/orchestrator.go → Model coordination
-  modelproc/processor.go       → Individual model calls
-internal/providers/openrouter/ → API client
-internal/models/models.go      → Model definitions (ADD NEW MODELS HERE)
-internal/logutil/              → Console output + TUI components
-internal/fileutil/             → File filtering, gitignore
+lib/thinktank/cli.ex            → Escript entry, arg parsing, dispatch
+lib/thinktank/router.ex         → LLM-powered perspective generation
+lib/thinktank/perspective.ex    → Perspective struct (role + model + prompt)
+lib/thinktank/dispatch/quick.ex → Parallel OpenRouter API calls
+lib/thinktank/dispatch/deep.ex  → Pi subprocess orchestration via MuonTrap
+lib/thinktank/openrouter.ex     → OpenRouter HTTP client (Req)
+lib/thinktank/synthesis.ex      → Structured fan-in with retry
+lib/thinktank/output.ex         → Kill-safe artifact writer + manifest
+lib/thinktank/application.ex    → OTP supervision tree
 ```
 
-**Start here:** `internal/cli/run.go:50` - the `Run()` function shows the full execution flow.
+**Start here:** `lib/thinktank/cli.ex` — the `main/1` function shows the full execution flow.
 
 ## Run & Test
 
 ```bash
-# Build & run
-go build ./... && thinktank instructions.txt ./src --dry-run
+# Build escript
+mix escript.build
 
-# Test (race detection required before commit)
-go test -race ./...
+# Run
+./thinktank "research question" --paths ./src --quick --dry-run
 
-# Coverage (79% minimum)
-./scripts/check-coverage.sh
+# Test
+mix test
 
-# Lint (fix all violations)
-golangci-lint run ./...
+# Format (required before push)
+mix format
+mix format --check-formatted
 
-# Vulnerability scan (hard fail)
-govulncheck -scan=module
+# Compile with warnings-as-errors
+mix compile --warnings-as-errors
+
+# Dialyzer (when available)
+mix dialyzer
 ```
 
-**Required env:** `OPENROUTER_API_KEY` (single key for all models)
+**Required env:** `OPENROUTER_API_KEY` or `THINKTANK_OPENROUTER_API_KEY`
+
+### Legacy Go (archiving — see #250)
+
+```bash
+go build ./... && go test -race ./...
+golangci-lint run ./...
+./scripts/check-coverage.sh   # 79% minimum
+govulncheck -scan=module
+```
 
 ## Quality & Pitfalls
 
 ### Definition of Done
-- Tests pass with `-race`
-- Coverage ≥79%
-- golangci-lint clean
+- `mix test` passes
+- `mix format --check-formatted` clean
+- `mix compile --warnings-as-errors` clean
 - Conventional commit message
 
 ### Critical Invariants
-- **No error suppression**: Never ignore errors with `_`. Fix them.
+- **No error suppression**: Handle every `{:error, _}` explicitly
 - **TDD**: Write tests first, then implement
-- **Direct function testing**: Use dependency injection, not subprocess tests
-- **Dual logging**: ConsoleWriter for users, structured JSON for debugging
+- **Run `mix format` before push**
+- **Kill-safe output**: Atomic manifest writes (tmp + rename) in `Output`
+- **Defensive deserialization**: Type guards and nil filtering for LLM structured output
 
 ### Model IDs — Mechanical Enforcement
-- **Single source of truth**: `internal/models/models.go` — ALL model IDs come from here
-- **NEVER write a model ID from memory** — always read models.go first
+- **Default models live in** `lib/thinktank/cli.ex` `@default_models`
+- **Go registry**: `internal/models/models.go` — legacy source of truth until #250 archives Go
 - **Pre-commit hook**: `scripts/validate-elixir-models.sh` rejects Elixir commits with model IDs not in Go registry
-- **If models.go is stale**: WebSearch OpenRouter models page, update models.go, then use the ID
-- **Validation**: `scripts/validate-elixir-models.sh` (run manually or via pre-commit)
-
-### Adding New Models
-1. Edit `internal/models/models.go` → add to `ModelDefinitions` map
-2. Run `go test ./internal/models && go test ./...`
-3. Run `scripts/validate-elixir-models.sh` to verify cross-codebase consistency
-4. Test: `thinktank instructions.txt ./src --dry-run`
-
-### TUI/Terminal Output (internal/logutil)
-- Use `runewidth.StringWidth()` for alignment, not `len()` (Unicode width ≠ bytes)
-- Use `AdaptiveColor{Light: dark, Dark: light}` for accessibility
-- Provide ASCII fallbacks when `!isInteractive` (CI/logs)
-- Structs with goroutines need `Stop()` method + `t.Cleanup(obj.Stop)` in tests
-- Render methods are lock-free; caller owns serialization (consoleWriter)
+- **If models are stale**: WebSearch OpenRouter models page, update both, then use the ID
 
 ### Pre-commit Hooks
 ```bash
 pre-commit install  # One-time setup
 ```
-Timeouts: lint 4min, coverage 8min. Skip with `--no-verify` (sparingly).
+Hooks: gitleaks, trailing-whitespace, go-fmt, go-vet, mix-format, validate-elixir-models.
 
 ## References
 
-- [README.md](README.md) - Usage, CLI flags, model list
-- [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) - License policy, detailed setup
-- [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) - Common issues
-- [AGENTS.md](AGENTS.md) - Coding style, testing guidelines
+- [README.md](README.md) — Usage, CLI flags, model list
+- [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) — License policy, detailed setup
+- [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) — Common issues
+- [.groom/BACKLOG.md](.groom/BACKLOG.md) — Prioritized backlog
+- [.groom/plan-*.md](.groom/) — Sprint plans


### PR DESCRIPTION
## Why This Matters

Every agent session hitting this repo gets Go-oriented instructions while active development is Elixir. The architecture map points to `internal/cli/run.go:50` which doesn't reflect reality. This misdirects AI agents building Elixir features, wasting context and producing wrong commands.

Fixes #263

## Trade-offs / Risks

- Go commands are kept but demoted to a "Legacy" subsection rather than removed — this preserves utility until #250 archives Go entirely
- AGENTS.md is heavily reduced rather than deleted — keeps a landing pad for agents that load it, avoids broken references

## Intent Reference

Rewrite CLAUDE.md so architecture map, start-here pointer, run/test commands, and invariants reflect Elixir-primary reality. Reduce AGENTS.md from Go-specific to Elixir-only minimal content.

Source: [#263](https://github.com/misty-step/thinktank/issues/263)

## Changes

- **CLAUDE.md**: Rewrote architecture map to show `lib/thinktank/*.ex` modules. "Start here" now points to `lib/thinktank/cli.ex`. Run & Test section leads with `mix test`, `mix format`, `mix compile --warnings-as-errors`, `mix dialyzer`. Go commands moved to clearly-marked legacy subsection. Critical invariants include `mix format` before push, defensive deserialization, kill-safe output. References now include `.groom/` artifacts.
- **AGENTS.md**: Reduced from 47 lines of Go-specific guidelines to 12 lines of Elixir style + pointer to CLAUDE.md.

## Alternatives Considered

1. **Do nothing** — Agents keep getting wrong instructions. Rejected.
2. **Delete AGENTS.md entirely** — Simpler but breaks any tooling that loads it. Kept minimal instead.
3. **Full dual-language parity** — Maintaining equal Go/Elixir sections adds maintenance burden for a legacy codebase. Demote instead.

## Acceptance Criteria

From #263:
- [x] Architecture map shows Elixir modules (`lib/thinktank/*.ex`)
- [x] "Start here" points to `lib/thinktank/cli.ex`
- [x] Run & Test includes `mix test`, `mix format --check-formatted`, `mix dialyzer`
- [x] Go section clearly marked as legacy/archiving
- [x] Critical Invariants includes "Run `mix format` before push"
- [x] References includes `.groom/` artifacts
- [x] AGENTS.md reduced to Elixir-only content

## Manual QA

```bash
# Verify CLAUDE.md architecture map references valid files
grep -oP 'lib/thinktank/\S+\.ex' CLAUDE.md | while read f; do test -f "$f" && echo "OK: $f" || echo "MISSING: $f"; done

# Verify start-here file exists
test -f lib/thinktank/cli.ex && echo "Start-here exists"

# Verify Go section is marked legacy
grep -c "Legacy Go" CLAUDE.md  # should be 1

# Verify AGENTS.md points to CLAUDE.md
head -3 AGENTS.md
```

## What Changed

<details>
<summary>Before/After flow</summary>

**Before:** CLAUDE.md → Go architecture map → Go commands → Go invariants. AGENTS.md → duplicate Go guidelines.

**After:** CLAUDE.md → Elixir architecture map → Elixir commands → Elixir invariants → Legacy Go subsection. AGENTS.md → minimal Elixir style + pointer.

```mermaid
graph TD
    subgraph "Before (master)"
        A[CLAUDE.md] --> B[Go arch map]
        A --> C[Go commands]
        A --> D[Go invariants]
        E[AGENTS.md] --> F[Go style guide]
        E --> G[Go test guidelines]
    end
```

```mermaid
graph TD
    subgraph "After (this PR)"
        A2[CLAUDE.md] --> B2[Elixir arch map]
        A2 --> C2[Elixir commands]
        A2 --> D2[Elixir invariants]
        A2 --> E2["Legacy Go (collapsed)"]
        F2[AGENTS.md] --> G2[Elixir style only]
        F2 -.-> A2
    end
```

```mermaid
flowchart LR
    Agent[AI Agent] --> Load[Load CLAUDE.md]
    Load --> Map[Elixir arch map]
    Map --> Start["Start: cli.ex"]
    Start --> Commands["mix test / mix format"]
    Agent --> LoadA[Load AGENTS.md]
    LoadA --> Pointer[See CLAUDE.md]
```

</details>

## Test Coverage

Documentation-only change. Verified all Elixir tests pass:
- `mix test` — 94 tests, 0 failures
- `mix format --check-formatted` — clean
- `mix compile --warnings-as-errors` — clean

## Merge Confidence

**High.** Documentation-only change with no code impact. All quality gates pass. Every file referenced in the new architecture map exists and is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project architecture documentation to reflect Elixir-based approach
  * Revised build and test command workflows
  * Updated environment setup requirements and alternatives
  * Enhanced development guidelines for code quality and pre-commit checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->