### PR TITLE
fix: remove trufflehog base/head overrides that break on push events

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -22,6 +22,4 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
           extra_args: --results=verified,unknown


### PR DESCRIPTION
## Summary
- Removes explicit `base`/`head` params from the trufflehog workflow that caused every merge-to-master push event to fail with "BASE and HEAD are the same"
- The action's built-in push-event logic already uses `github.event.before` as base, which correctly scans only the newly merged commits

## Test plan
- [ ] Verify trufflehog workflow passes on this PR (pull_request event)
- [ ] After merge, verify trufflehog passes on the resulting push event

🤖 Generated with [Claude Code](https://claude.com/claude-code)