### PR TITLE
fix(deep): resolve escript stdin hang and restore post-merge hook

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -46,7 +46,7 @@
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
       #
-      strict: false,
+      strict: true,
       #
       # To modify the timeout for parsing files, change this value:
       #

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Cache PLTs
         uses: actions/cache@v4
         with:
-          path: _build/dev/dialyxir_*
+          path: |
+            _build/dev/dialyze_erlang-*_elixir-*_deps-dev.plt
+            ~/.mix/dialyxir_erlang-*.plt
           key: ${{ runner.os }}-plt-otp28-elixir1.19-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-plt-otp28-elixir1.19-
 

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -28,6 +28,13 @@ jobs:
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
 
+      - name: Cache PLTs
+        uses: actions/cache@v4
+        with:
+          path: _build/dev/dialyxir_*
+          key: ${{ runner.os }}-plt-otp28-elixir1.19-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-plt-otp28-elixir1.19-
+
       - name: Install dependencies
         run: mix deps.get
 
@@ -37,8 +44,16 @@ jobs:
       - name: Compile (warnings as errors)
         run: mix compile --warnings-as-errors
 
-      - name: Credo (strict)
-        run: mix credo --strict
+      - name: Credo
+        run: mix credo
+
+      - name: Dialyzer
+        run: mix dialyzer
+        env:
+          MIX_ENV: dev
+
+      - name: Hex audit
+        run: mix hex.audit
 
       - name: Run tests
         run: mix test

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ Thumbs.db
 # Environment and credentials
 .env
 agent_config/auth.json
+agent_config/cache/
+agent_config/logs/
 
 # Temporary files
 /tmp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
     -   id: mix-credo
         name: mix-credo
-        entry: mix credo --strict
+        entry: mix credo
         language: system
         files: \.exs?$
         pass_filenames: false

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+post-merge:
+  commands:
+    reinstall:
+      run: |
+        echo "thinktank: rebuilding escript after pull..."
+        if mix deps.get --quiet && mix escript.build 2>&1; then
+          echo "thinktank updated: $(./thinktank --version)"
+        else
+          echo "thinktank escript build failed"
+          exit 1
+        fi

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -7,16 +7,7 @@ defmodule Thinktank.CLI do
   JSON output, meaningful exit codes, no interactive prompts.
   """
 
-  alias Thinktank.{Dispatch.Deep, Dispatch.Quick, Output, Router, Synthesis}
-
-  # Verified against OpenRouter API (March 2026)
-  # curl -s https://openrouter.ai/api/v1/models | jq '.data[].id'
-  @default_models [
-    "anthropic/claude-sonnet-4.6",
-    "openai/gpt-5.4",
-    "google/gemini-3.1-pro-preview",
-    "deepseek/deepseek-v3.2"
-  ]
+  alias Thinktank.{Dispatch.Deep, Dispatch.Quick, Models, Output, Router, Synthesis}
 
   @exit_codes %{
     success: 0,
@@ -45,7 +36,8 @@ defmodule Thinktank.CLI do
       roles: :string,
       dry_run: :boolean,
       no_synthesis: :boolean,
-      perspectives: :integer
+      perspectives: :integer,
+      tier: :string
     ],
     aliases: [
       h: :help,
@@ -53,7 +45,8 @@ defmodule Thinktank.CLI do
       q: :quick,
       d: :deep,
       o: :output,
-      n: :perspectives
+      n: :perspectives,
+      t: :tier
     ]
   ]
 
@@ -130,6 +123,7 @@ defmodule Thinktank.CLI do
       paths: opts.paths,
       perspectives: opts.perspectives,
       dispatch_mode: to_string(opts.mode),
+      tier: to_string(opts.tier),
       models: opts.models,
       roles: opts.roles,
       no_synthesis: opts.no_synthesis
@@ -158,7 +152,8 @@ defmodule Thinktank.CLI do
       roles: parse_csv(parsed[:roles]),
       dry_run: parsed[:dry_run] || false,
       no_synthesis: parsed[:no_synthesis] || false,
-      perspectives: parsed[:perspectives] || 4
+      perspectives: parsed[:perspectives] || 4,
+      tier: parse_tier(parsed[:tier])
     }
   end
 
@@ -198,19 +193,19 @@ defmodule Thinktank.CLI do
         IO.puts(:stderr, "Error: #{reason}")
         System.halt(@exit_codes.input_error)
 
-      {:ok, perspectives} ->
+      {:ok, perspectives, router_usage} ->
         output_dir = opts.output || generate_output_dir()
-        roles = Enum.map(perspectives, & &1.role)
-        Output.init_run(output_dir, roles)
+        Output.init_run(output_dir, perspectives, router_usage)
 
         results = dispatch_fn.(perspectives, opts.instruction, opts.paths)
-        successes = for {:ok, role, text} <- results, do: {role, text}
+        successes = for {:ok, role, text, usage} <- results, do: {role, text, usage}
 
-        for {role, text} <- successes do
-          Output.write_perspective(output_dir, role, text)
+        for {role, text, usage} <- successes do
+          Output.write_perspective(output_dir, role, text, usage)
         end
 
-        maybe_synthesize(opts, successes, output_dir)
+        synthesis_successes = for {role, text, _usage} <- successes, do: {role, text}
+        maybe_synthesize(opts, synthesis_successes, output_dir)
         Output.complete_run(output_dir)
         emit_result(opts, output_dir)
         exit_on_results(successes)
@@ -224,8 +219,8 @@ defmodule Thinktank.CLI do
   end
 
   defp do_synthesize(opts, successes, output_dir) do
-    case Synthesis.synthesize(successes, opts.instruction) do
-      {:ok, text} -> Output.write_synthesis(output_dir, text)
+    case Synthesis.synthesize(successes, opts.instruction, tier: opts.tier) do
+      {:ok, text, usage} -> Output.write_synthesis(output_dir, text, usage)
       {:error, _} -> IO.puts(:stderr, "Warning: synthesis failed after retries")
     end
   end
@@ -238,7 +233,7 @@ defmodule Thinktank.CLI do
     end
   end
 
-  @spec exit_on_results([{String.t(), String.t()}]) :: no_return()
+  @spec exit_on_results([{String.t(), String.t(), map() | nil}]) :: no_return()
   defp exit_on_results([]) do
     IO.puts(:stderr, "Error: all perspective dispatches failed")
     System.halt(@exit_codes.generic_error)
@@ -247,14 +242,15 @@ defmodule Thinktank.CLI do
   defp exit_on_results(_successes), do: System.halt(@exit_codes.success)
 
   defp resolve_perspectives(opts) do
-    models = if opts.models != [], do: opts.models, else: @default_models
+    models = if opts.models != [], do: opts.models, else: Models.models_for_tier(opts.tier)
 
     if opts.roles != [] do
-      {:ok, Router.manual_perspectives(opts.roles, models)}
+      {:ok, Router.manual_perspectives(opts.roles, models), nil}
     else
       Router.generate_perspectives(opts.instruction, opts.paths,
         available_models: models,
-        perspectives: opts.perspectives
+        perspectives: opts.perspectives,
+        tier: opts.tier
       )
     end
   end
@@ -280,9 +276,10 @@ defmodule Thinktank.CLI do
       --paths PATH     Files/dirs for agent context (repeatable)
       --quick, -q      Quick mode: parallel API calls, no tools
       --deep, -d       Deep mode: Pi agent subprocesses (default)
+      --tier, -t TIER  Model tier: cheap, standard, premium (default: standard)
       --json           Output structured JSON to stdout
       --output, -o     Output directory (default: auto-generated)
-      --models LIST    Comma-separated model list (overrides router)
+      --models LIST    Comma-separated model list (overrides tier)
       --roles LIST     Comma-separated roles (bypasses router)
       --perspectives N Number of perspectives (default: 4)
       --dry-run        Show plan without executing
@@ -305,11 +302,19 @@ defmodule Thinktank.CLI do
 
     EXAMPLES
       thinktank "review this auth flow" --paths ./src/auth
-      thinktank "suggest project names" --quick
-      thinktank "audit for security issues" --paths ./src --perspectives 5
-      echo "compare approaches" | thinktank --models claude-opus-4-6,gpt-5.4 --quick
+      thinktank "suggest project names" --quick --tier cheap
+      thinktank "audit for security issues" --tier premium --perspectives 5
+      echo "compare approaches" | thinktank --quick
     """)
   end
+
+  defp parse_tier(nil), do: :standard
+  defp parse_tier("cheap"), do: :cheap
+  defp parse_tier("standard"), do: :standard
+  defp parse_tier("premium"), do: :premium
+
+  defp parse_tier(other),
+    do: raise("invalid tier: #{other} (must be cheap, standard, or premium)")
 
   defp parse_csv(nil), do: []
   defp parse_csv(str), do: str |> String.split(",") |> Enum.map(&String.trim/1)

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -57,11 +57,13 @@ defmodule Thinktank.CLI do
     ]
   ]
 
+  @spec exit_codes() :: %{atom() => non_neg_integer()}
   def exit_codes, do: @exit_codes
 
   @doc """
   Escript entry point.
   """
+  @spec main([String.t()]) :: no_return()
   def main(args) do
     result =
       case parse_args(args) do
@@ -89,6 +91,12 @@ defmodule Thinktank.CLI do
   end
 
   @doc false
+  @spec parse_args([String.t()]) ::
+          {:ok, map()}
+          | {:error, String.t()}
+          | {:help, keyword()}
+          | {:version, keyword()}
+          | {:needs_stdin, keyword()}
   def parse_args(args) do
     {parsed, rest, invalid} = OptionParser.parse(args, @option_spec)
 
@@ -114,6 +122,7 @@ defmodule Thinktank.CLI do
   @doc """
   Returns the JSON string for dry-run output.
   """
+  @spec dry_run_output(map()) :: String.t()
   def dry_run_output(opts) do
     Jason.encode!(%{
       mode: "dry_run",
@@ -153,6 +162,7 @@ defmodule Thinktank.CLI do
     }
   end
 
+  @spec run(map()) :: no_return()
   defp run(%{dry_run: true} = opts) do
     if opts.json do
       IO.puts(dry_run_output(opts))
@@ -181,6 +191,7 @@ defmodule Thinktank.CLI do
     end)
   end
 
+  @spec dispatch_and_finalize(map(), function()) :: no_return()
   defp dispatch_and_finalize(opts, dispatch_fn) do
     case resolve_perspectives(opts) do
       {:error, reason} ->
@@ -227,6 +238,7 @@ defmodule Thinktank.CLI do
     end
   end
 
+  @spec exit_on_results([{String.t(), String.t()}]) :: no_return()
   defp exit_on_results([]) do
     IO.puts(:stderr, "Error: all perspective dispatches failed")
     System.halt(@exit_codes.generic_error)

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -108,7 +108,10 @@ defmodule Thinktank.CLI do
         {:needs_stdin, parsed}
 
       true ->
-        {:ok, build_opts(Enum.join(rest, " "), parsed)}
+        case parse_tier(parsed[:tier]) do
+          {:ok, tier} -> {:ok, build_opts(Enum.join(rest, " "), parsed, tier)}
+          {:error, _} = err -> err
+        end
     end
   end
 
@@ -134,14 +137,16 @@ defmodule Thinktank.CLI do
     with true <- stdin_piped?(),
          data when is_binary(data) <- IO.read(:stdio, :eof),
          trimmed = String.trim(data),
-         false <- trimmed == "" do
-      {:ok, build_opts(trimmed, parsed)}
+         false <- trimmed == "",
+         {:ok, tier} <- parse_tier(parsed[:tier]) do
+      {:ok, build_opts(trimmed, parsed, tier)}
     else
+      {:error, _} = err -> err
       _ -> {:error, "instruction argument required"}
     end
   end
 
-  defp build_opts(instruction, parsed) do
+  defp build_opts(instruction, parsed, tier) do
     %{
       instruction: instruction,
       paths: parsed |> Keyword.get_values(:paths) |> Enum.map(&Path.expand/1),
@@ -153,7 +158,7 @@ defmodule Thinktank.CLI do
       dry_run: parsed[:dry_run] || false,
       no_synthesis: parsed[:no_synthesis] || false,
       perspectives: parsed[:perspectives] || 4,
-      tier: parse_tier(parsed[:tier])
+      tier: tier
     }
   end
 
@@ -308,13 +313,13 @@ defmodule Thinktank.CLI do
     """)
   end
 
-  defp parse_tier(nil), do: :standard
-  defp parse_tier("cheap"), do: :cheap
-  defp parse_tier("standard"), do: :standard
-  defp parse_tier("premium"), do: :premium
+  defp parse_tier(nil), do: {:ok, :standard}
+  defp parse_tier("cheap"), do: {:ok, :cheap}
+  defp parse_tier("standard"), do: {:ok, :standard}
+  defp parse_tier("premium"), do: {:ok, :premium}
 
   defp parse_tier(other),
-    do: raise("invalid tier: #{other} (must be cheap, standard, or premium)")
+    do: {:error, "invalid tier: #{other} (must be cheap, standard, or premium)"}
 
   defp parse_csv(nil), do: []
   defp parse_csv(str), do: str |> String.split(",") |> Enum.map(&String.trim/1)

--- a/lib/thinktank/dispatch/deep.ex
+++ b/lib/thinktank/dispatch/deep.ex
@@ -7,11 +7,11 @@ defmodule Thinktank.Dispatch.Deep do
   available (mix/release) for OS-level kill-safety; falls back to
   System.cmd for escripts where MuonTrap's priv binary is inaccessible.
 
-  Returns the same result tuples as `Dispatch.Quick` so the caller
-  (CLI) doesn't care which mode ran.
+  Returns the same result tuples as `Dispatch.Quick` (with `nil` usage)
+  so the caller (CLI) doesn't care which mode ran.
   """
 
-  @type result :: {:ok, String.t(), String.t()} | {:error, String.t(), map()}
+  @type result :: {:ok, String.t(), String.t(), map() | nil} | {:error, String.t(), map()}
 
   @default_timeout :timer.minutes(30)
   @default_tools "read,bash,grep,find"
@@ -19,7 +19,8 @@ defmodule Thinktank.Dispatch.Deep do
   @doc """
   Dispatch Pi agent subprocesses for each perspective.
 
-  Returns a list of `{:ok, role, text}` or `{:error, role, error_map}` tuples.
+  Returns a list of `{:ok, role, text, usage}` or `{:error, role, error_map}` tuples.
+  Usage is `nil` for deep mode (Pi subprocesses don't report API usage).
 
   Options:
     - `:paths` — file paths for agent context (starting points)
@@ -65,7 +66,7 @@ defmodule Thinktank.Dispatch.Deep do
 
     case runner.("sh", ["-c", shell_cmd], cmd_opts) do
       {output, 0} ->
-        {:ok, perspective.role, output}
+        {:ok, perspective.role, output, nil}
 
       {output, :timeout} ->
         {:error, perspective.role, %{category: :timeout, output: output}}

--- a/lib/thinktank/dispatch/deep.ex
+++ b/lib/thinktank/dispatch/deep.ex
@@ -3,9 +3,9 @@ defmodule Thinktank.Dispatch.Deep do
   Deep mode dispatch via Pi agent subprocesses.
 
   Spawns N Pi agents in parallel under Task.Supervisor, each with a
-  unique perspective, model, and system prompt. MuonTrap wraps each
-  subprocess: if the parent dies (SIGTERM, crash), all children are
-  killed at the OS level.
+  unique perspective, model, and system prompt. Uses MuonTrap when
+  available (mix/release) for OS-level kill-safety; falls back to
+  System.cmd for escripts where MuonTrap's priv binary is inaccessible.
 
   Returns the same result tuples as `Dispatch.Quick` so the caller
   (CLI) doesn't care which mode ran.
@@ -23,13 +23,13 @@ defmodule Thinktank.Dispatch.Deep do
 
   Options:
     - `:paths` — file paths for agent context (starting points)
-    - `:runner` — `fn cmd, args, opts -> {output, exit_status}` (default: `&MuonTrap.cmd/3`)
+    - `:runner` — `fn cmd, args, opts -> {output, exit_status}` (default: auto-detected)
     - `:agent_config_dir` — path for PI_CODING_AGENT_DIR env var
     - `:timeout` — per-agent timeout in ms (default: 30 min)
   """
   @spec dispatch([Thinktank.Perspective.t()], String.t(), keyword()) :: [result()]
   def dispatch(perspectives, instruction, opts \\ []) do
-    runner = opts[:runner] || (&MuonTrap.cmd/3)
+    runner = opts[:runner] || default_runner()
     timeout = opts[:timeout] || @default_timeout
 
     tasks =
@@ -39,7 +39,6 @@ defmodule Thinktank.Dispatch.Deep do
         end)
       end)
 
-    # Grace period: let MuonTrap's timeout fire first for cleaner error reporting
     tasks
     |> Task.yield_many(timeout + 5_000)
     |> Enum.zip(perspectives)
@@ -60,20 +59,11 @@ defmodule Thinktank.Dispatch.Deep do
   defp run_agent(perspective, instruction, opts, runner) do
     prompt = build_prompt(perspective.system_prompt, instruction, opts[:paths] || [])
 
-    args = [
-      "--no-session",
-      "--no-skills",
-      "--model",
-      perspective.model,
-      "--tools",
-      @default_tools,
-      "-p",
-      prompt
-    ]
-
+    # Pi hangs when Erlang ports keep stdin open — wrap via sh to close it.
+    shell_cmd = build_shell_cmd(perspective.model, prompt)
     cmd_opts = build_cmd_opts(opts)
 
-    case runner.("pi", args, cmd_opts) do
+    case runner.("sh", ["-c", shell_cmd], cmd_opts) do
       {output, 0} ->
         {:ok, perspective.role, output}
 
@@ -86,6 +76,14 @@ defmodule Thinktank.Dispatch.Deep do
   rescue
     e ->
       {:error, perspective.role, %{category: :crash, message: Exception.message(e)}}
+  end
+
+  defp build_shell_cmd(model, prompt) do
+    escaped_prompt = prompt |> String.replace("'", "'\\''")
+    escaped_model = model |> String.replace("'", "'\\''")
+
+    "pi --no-session --no-skills --model '#{escaped_model}'" <>
+      " --tools #{@default_tools} -p '#{escaped_prompt}' < /dev/null"
   end
 
   defp build_prompt(system_prompt, instruction, []) do
@@ -104,6 +102,33 @@ defmodule Thinktank.Dispatch.Deep do
     case opts[:agent_config_dir] do
       nil -> base
       dir -> Keyword.put(base, :env, [{"PI_CODING_AGENT_DIR", dir}])
+    end
+  end
+
+  # MuonTrap's priv binary is unavailable in escripts — fall back to System.cmd.
+  defp default_runner do
+    if muontrap_available?(), do: &MuonTrap.cmd/3, else: &system_cmd/3
+  end
+
+  defp muontrap_available? do
+    path = MuonTrap.muontrap_path()
+    File.exists?(path)
+  rescue
+    _ -> false
+  end
+
+  defp system_cmd(cmd, args, opts) do
+    timeout = Keyword.get(opts, :timeout, @default_timeout)
+    env = Keyword.get(opts, :env, [])
+
+    task =
+      Task.async(fn ->
+        System.cmd(cmd, args, stderr_to_stdout: true, env: env)
+      end)
+
+    case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {output, exit_code}} -> {output, exit_code}
+      nil -> {"", :timeout}
     end
   end
 end

--- a/lib/thinktank/dispatch/deep.ex
+++ b/lib/thinktank/dispatch/deep.ex
@@ -83,7 +83,7 @@ defmodule Thinktank.Dispatch.Deep do
     escaped_prompt = prompt |> String.replace("'", "'\\''")
     escaped_model = model |> String.replace("'", "'\\''")
 
-    "pi --no-session --no-skills --model '#{escaped_model}'" <>
+    "exec pi --no-session --no-skills --model '#{escaped_model}'" <>
       " --tools #{@default_tools} -p '#{escaped_prompt}' < /dev/null"
   end
 
@@ -118,6 +118,9 @@ defmodule Thinktank.Dispatch.Deep do
     _ -> false
   end
 
+  # Escript fallback: System.cmd does NOT provide OS-level kill-safety.
+  # On timeout, the Elixir task is killed but the OS process (pi) may
+  # survive. MuonTrap path (mix/release) provides true kill-safety.
   defp system_cmd(cmd, args, opts) do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     env = Keyword.get(opts, :env, [])

--- a/lib/thinktank/dispatch/quick.ex
+++ b/lib/thinktank/dispatch/quick.ex
@@ -13,12 +13,12 @@ defmodule Thinktank.Dispatch.Quick do
   @timeout :timer.minutes(5)
   @max_file_bytes 100_000
 
-  @type result :: {:ok, String.t(), String.t()} | {:error, String.t(), map()}
+  @type result :: {:ok, String.t(), String.t(), map() | nil} | {:error, String.t(), map()}
 
   @doc """
   Dispatch parallel API calls for each perspective.
 
-  Returns a list of `{:ok, role, text}` or `{:error, role, error_map}` tuples
+  Returns a list of `{:ok, role, text, usage}` or `{:error, role, error_map}` tuples
   in the same order as the input perspectives.
 
   Options:
@@ -35,7 +35,7 @@ defmodule Thinktank.Dispatch.Quick do
     |> Task.async_stream(
       fn p ->
         case OpenRouter.chat(p.model, p.system_prompt, prompt, or_opts) do
-          {:ok, text} -> {:ok, p.role, text}
+          {:ok, text, usage} -> {:ok, p.role, text, usage}
           {:error, err} -> {:error, p.role, err}
         end
       end,

--- a/lib/thinktank/models.ex
+++ b/lib/thinktank/models.ex
@@ -1,0 +1,67 @@
+defmodule Thinktank.Models do
+  @moduledoc """
+  Single source of truth for model metadata across all tiers.
+
+  Three tiers — cheap, standard, premium — each with a set of
+  dispatch models plus designated router and synthesis models.
+  """
+
+  @type tier :: :cheap | :standard | :premium
+
+  @tiers %{
+    cheap: %{
+      models: [
+        "qwen/qwen3.5-9b",
+        "nvidia/nemotron-3-nano-30b-a3b",
+        "bytedance-seed/seed-2.0-mini",
+        "qwen/qwen3.5-flash-02-23"
+      ],
+      router: "qwen/qwen3.5-flash-02-23",
+      synthesis: "qwen/qwen3.5-flash-02-23"
+    },
+    standard: %{
+      models: [
+        "deepseek/deepseek-v3.2",
+        "x-ai/grok-4.1-fast",
+        "inception/mercury-2",
+        "google/gemini-3-flash-preview",
+        "mistralai/mistral-large-2512",
+        "anthropic/claude-haiku-4.5"
+      ],
+      router: "google/gemini-3-flash-preview",
+      synthesis: "google/gemini-3-flash-preview"
+    },
+    premium: %{
+      models: [
+        "google/gemini-3.1-pro-preview",
+        "openai/gpt-5.4",
+        "anthropic/claude-sonnet-4.6",
+        "x-ai/grok-4.20-beta",
+        "anthropic/claude-opus-4.6"
+      ],
+      router: "google/gemini-3.1-pro-preview",
+      synthesis: "google/gemini-3.1-pro-preview"
+    }
+  }
+
+  @spec models_for_tier(tier()) :: [String.t()]
+  def models_for_tier(tier), do: @tiers[tier].models
+
+  @spec tier_for_model(String.t()) :: tier() | nil
+  def tier_for_model(model_id) do
+    Enum.find_value(@tiers, fn {tier, %{models: models}} ->
+      if model_id in models, do: tier
+    end)
+  end
+
+  @spec router_model(tier()) :: String.t()
+  def router_model(tier), do: @tiers[tier].router
+
+  @spec synthesis_model(tier()) :: String.t()
+  def synthesis_model(tier), do: @tiers[tier].synthesis
+
+  @spec all_model_ids() :: [String.t()]
+  def all_model_ids do
+    @tiers |> Map.values() |> Enum.flat_map(& &1.models) |> Enum.uniq()
+  end
+end

--- a/lib/thinktank/models.ex
+++ b/lib/thinktank/models.ex
@@ -47,6 +47,7 @@ defmodule Thinktank.Models do
   @spec models_for_tier(tier()) :: [String.t()]
   def models_for_tier(tier), do: @tiers[tier].models
 
+  @doc false
   @spec tier_for_model(String.t()) :: tier() | nil
   def tier_for_model(model_id) do
     Enum.find_value(@tiers, fn {tier, %{models: models}} ->
@@ -60,6 +61,7 @@ defmodule Thinktank.Models do
   @spec synthesis_model(tier()) :: String.t()
   def synthesis_model(tier), do: @tiers[tier].synthesis
 
+  @doc false
   @spec all_model_ids() :: [String.t()]
   def all_model_ids do
     @tiers |> Map.values() |> Enum.flat_map(& &1.models) |> Enum.uniq()

--- a/lib/thinktank/openrouter.ex
+++ b/lib/thinktank/openrouter.ex
@@ -8,6 +8,8 @@ defmodule Thinktank.OpenRouter do
 
   @base_url "https://openrouter.ai/api/v1"
 
+  @spec chat(String.t(), String.t(), String.t(), keyword()) ::
+          {:ok, String.t() | nil} | {:error, map()}
   def chat(model, system_prompt, user_prompt, opts \\ []) do
     with {:ok, key} <- require_key(opts) do
       build_req(key, opts)
@@ -19,6 +21,8 @@ defmodule Thinktank.OpenRouter do
     end
   end
 
+  @spec chat_structured(String.t(), String.t(), String.t(), map(), keyword()) ::
+          {:ok, map()} | {:error, map()}
   def chat_structured(model, system_prompt, user_prompt, json_schema, opts \\ []) do
     with {:ok, key} <- require_key(opts) do
       body = %{

--- a/lib/thinktank/openrouter.ex
+++ b/lib/thinktank/openrouter.ex
@@ -137,7 +137,8 @@ defmodule Thinktank.OpenRouter do
     end
   end
 
-  defp wrap_json({:ok, parsed}, _raw), do: {:ok, parsed}
+  defp wrap_json({:ok, parsed}, _raw) when is_map(parsed), do: {:ok, parsed}
+  defp wrap_json({:ok, non_map}, _raw), do: {:error, %{category: :invalid_json, raw: non_map}}
   defp wrap_json({:error, _}, raw), do: {:error, %{category: :invalid_json, raw: raw}}
 
   defp non_empty_env(name) do

--- a/lib/thinktank/openrouter.ex
+++ b/lib/thinktank/openrouter.ex
@@ -8,8 +8,15 @@ defmodule Thinktank.OpenRouter do
 
   @base_url "https://openrouter.ai/api/v1"
 
+  @type usage :: %{
+          prompt_tokens: non_neg_integer(),
+          completion_tokens: non_neg_integer(),
+          total_tokens: non_neg_integer(),
+          cost: float()
+        }
+
   @spec chat(String.t(), String.t(), String.t(), keyword()) ::
-          {:ok, String.t() | nil} | {:error, map()}
+          {:ok, String.t() | nil, usage()} | {:error, map()}
   def chat(model, system_prompt, user_prompt, opts \\ []) do
     with {:ok, key} <- require_key(opts) do
       build_req(key, opts)
@@ -22,7 +29,7 @@ defmodule Thinktank.OpenRouter do
   end
 
   @spec chat_structured(String.t(), String.t(), String.t(), map(), keyword()) ::
-          {:ok, map()} | {:error, map()}
+          {:ok, map(), usage()} | {:error, map()}
   def chat_structured(model, system_prompt, user_prompt, json_schema, opts \\ []) do
     with {:ok, key} <- require_key(opts) do
       body = %{
@@ -83,7 +90,12 @@ defmodule Thinktank.OpenRouter do
     end
   end
 
-  defp handle_response({:ok, %{status: 200, body: body}}, extractor), do: extractor.(body)
+  defp handle_response({:ok, %{status: 200, body: body}}, extractor) do
+    case extractor.(body) do
+      {:ok, content} -> {:ok, content, extract_usage(body)}
+      {:error, _} = err -> err
+    end
+  end
 
   defp handle_response({:ok, %{status: 401, body: body}}, _),
     do: {:error, %{category: :auth, message: error_message(body) || "unauthorized"}}
@@ -101,6 +113,17 @@ defmodule Thinktank.OpenRouter do
 
   defp handle_response({:error, reason}, _),
     do: {:error, %{category: :transport, message: inspect(reason)}}
+
+  defp extract_usage(body) do
+    usage = body["usage"] || %{}
+
+    %{
+      prompt_tokens: usage["prompt_tokens"] || 0,
+      completion_tokens: usage["completion_tokens"] || 0,
+      total_tokens: usage["total_tokens"] || 0,
+      cost: (body["cost"] || 0) * 1.0
+    }
+  end
 
   defp extract_text(body) do
     {:ok, get_in(body, ["choices", Access.at(0), "message", "content"])}

--- a/lib/thinktank/output.ex
+++ b/lib/thinktank/output.ex
@@ -11,10 +11,12 @@ defmodule Thinktank.Output do
 
   @doc """
   Initialize an output run: create the directory and write the
-  initial manifest with all perspectives in pending state.
+  initial manifest with full perspective configuration.
+
+  `router_usage` is the usage map from the routing LLM call, or nil.
   """
-  @spec init_run(Path.t(), [String.t()]) :: :ok
-  def init_run(output_dir, roles) do
+  @spec init_run(Path.t(), [Thinktank.Perspective.t()], map() | nil) :: :ok
+  def init_run(output_dir, perspectives, router_usage) do
     File.mkdir_p!(output_dir)
 
     manifest = %{
@@ -23,13 +25,18 @@ defmodule Thinktank.Output do
       "started_at" => now_iso8601(),
       "completed_at" => nil,
       "perspectives_completed" => 0,
+      "router_usage" => normalize_usage(router_usage),
       "perspectives" =>
-        Enum.map(roles, fn role ->
+        Enum.map(perspectives, fn p ->
           %{
-            "role" => role,
+            "role" => p.role,
+            "model" => p.model,
+            "system_prompt" => p.system_prompt,
+            "priority" => p.priority,
             "status" => "pending",
             "file" => nil,
-            "completed_at" => nil
+            "completed_at" => nil,
+            "usage" => nil
           }
         end)
     }
@@ -39,9 +46,11 @@ defmodule Thinktank.Output do
 
   @doc """
   Write a perspective's content to disk and update the manifest.
+
+  `usage` is the usage map from the LLM call, or nil (deep mode).
   """
-  @spec write_perspective(Path.t(), String.t(), String.t()) :: :ok
-  def write_perspective(output_dir, role, content) do
+  @spec write_perspective(Path.t(), String.t(), String.t(), map() | nil) :: :ok
+  def write_perspective(output_dir, role, content, usage) do
     filename = slugify(role) <> ".md"
     File.write!(Path.join(output_dir, filename), content)
 
@@ -50,7 +59,13 @@ defmodule Thinktank.Output do
     perspectives =
       Enum.map(manifest["perspectives"], fn p ->
         if p["role"] == role do
-          %{p | "status" => "complete", "file" => filename, "completed_at" => now_iso8601()}
+          %{
+            p
+            | "status" => "complete",
+              "file" => filename,
+              "completed_at" => now_iso8601(),
+              "usage" => normalize_usage(usage)
+          }
         else
           p
         end
@@ -67,9 +82,11 @@ defmodule Thinktank.Output do
 
   @doc """
   Write synthesis output and update manifest.
+
+  `usage` is the usage map from the synthesis LLM call, or nil.
   """
-  @spec write_synthesis(Path.t(), String.t()) :: :ok
-  def write_synthesis(output_dir, content) do
+  @spec write_synthesis(Path.t(), String.t(), map() | nil) :: :ok
+  def write_synthesis(output_dir, content, usage) do
     filename = "synthesis.md"
     File.write!(Path.join(output_dir, filename), content)
 
@@ -80,14 +97,16 @@ defmodule Thinktank.Output do
       Map.put(manifest, "synthesis", %{
         "status" => "complete",
         "file" => filename,
-        "completed_at" => now_iso8601()
+        "completed_at" => now_iso8601(),
+        "usage" => normalize_usage(usage)
       })
     )
   end
 
   @doc """
   Finalize the run. Sets status to "complete" if all perspectives
-  finished, "partial" otherwise.
+  finished, "partial" otherwise. Computes total_cost and total_tokens
+  by summing all usage sources (router, perspectives, synthesis).
   """
   @spec complete_run(Path.t()) :: :ok
   def complete_run(output_dir) do
@@ -97,20 +116,39 @@ defmodule Thinktank.Output do
 
     status = if completed == total, do: "complete", else: "partial"
 
-    write_manifest(output_dir, %{
-      manifest
-      | "status" => status,
-        "completed_at" => now_iso8601()
-    })
+    usages =
+      [manifest["router_usage"]] ++
+        Enum.map(manifest["perspectives"], & &1["usage"]) ++
+        [get_in(manifest, ["synthesis", "usage"])]
+
+    {total_cost, total_tokens} = sum_usages(usages)
+
+    write_manifest(
+      output_dir,
+      %{
+        manifest
+        | "status" => status,
+          "completed_at" => now_iso8601()
+      }
+      |> Map.put("total_cost", total_cost)
+      |> Map.put("total_tokens", total_tokens)
+    )
   end
 
-  @type perspective_summary :: %{role: String.t(), status: String.t(), file: String.t() | nil}
+  @type perspective_summary :: %{
+          role: String.t(),
+          model: String.t(),
+          status: String.t(),
+          file: String.t() | nil
+        }
 
   @type envelope :: %{
           output_dir: Path.t(),
           status: String.t(),
           perspectives: [perspective_summary()],
-          files: [String.t()]
+          files: [String.t()],
+          total_cost: float(),
+          total_tokens: non_neg_integer()
         }
 
   @doc """
@@ -127,14 +165,16 @@ defmodule Thinktank.Output do
 
     perspectives =
       Enum.map(manifest["perspectives"], fn p ->
-        %{role: p["role"], status: p["status"], file: p["file"]}
+        %{role: p["role"], model: p["model"], status: p["status"], file: p["file"]}
       end)
 
     base = %{
       output_dir: output_dir,
       status: manifest["status"],
       perspectives: perspectives,
-      files: files
+      files: files,
+      total_cost: manifest["total_cost"] || 0.0,
+      total_tokens: manifest["total_tokens"] || 0
     }
 
     case manifest["synthesis"] do
@@ -174,6 +214,28 @@ defmodule Thinktank.Output do
     File.write!(tmp, Jason.encode!(manifest, pretty: true))
     File.rename!(tmp, path)
     :ok
+  end
+
+  # Normalize usage map to string keys for JSON serialization.
+  # Handles both atom-keyed maps (from OpenRouter) and string-keyed (from manifest reads).
+  defp normalize_usage(nil), do: nil
+
+  defp normalize_usage(usage) when is_map(usage) do
+    %{
+      "prompt_tokens" => usage[:prompt_tokens] || usage["prompt_tokens"] || 0,
+      "completion_tokens" => usage[:completion_tokens] || usage["completion_tokens"] || 0,
+      "total_tokens" => usage[:total_tokens] || usage["total_tokens"] || 0,
+      "cost" => (usage[:cost] || usage["cost"] || 0) * 1.0
+    }
+  end
+
+  # Sum cost and tokens from a list of usage maps (nils filtered out).
+  defp sum_usages(usages) do
+    usages
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reduce({0.0, 0}, fn u, {cost, tokens} ->
+      {cost + (u["cost"] || 0), tokens + (u["total_tokens"] || 0)}
+    end)
   end
 
   defp now_iso8601, do: DateTime.utc_now() |> DateTime.to_iso8601()

--- a/lib/thinktank/output.ex
+++ b/lib/thinktank/output.ex
@@ -51,23 +51,29 @@ defmodule Thinktank.Output do
   """
   @spec write_perspective(Path.t(), String.t(), String.t(), map() | nil) :: :ok
   def write_perspective(output_dir, role, content, usage) do
-    filename = slugify(role) <> ".md"
-    File.write!(Path.join(output_dir, filename), content)
-
     manifest = read_manifest(output_dir)
 
-    perspectives =
-      Enum.map(manifest["perspectives"], fn p ->
-        if p["role"] == role do
-          %{
-            p
-            | "status" => "complete",
-              "file" => filename,
-              "completed_at" => now_iso8601(),
-              "usage" => normalize_usage(usage)
-          }
+    # Match first pending perspective with this role to handle duplicate roles.
+    # Priority-prefixed filename prevents file collisions.
+    target =
+      Enum.find(manifest["perspectives"], &(&1["role"] == role and &1["status"] == "pending"))
+
+    priority = if target, do: target["priority"], else: 0
+    filename = "#{priority}-#{slugify(role)}.md"
+    File.write!(Path.join(output_dir, filename), content)
+
+    {perspectives, _matched} =
+      Enum.map_reduce(manifest["perspectives"], false, fn p, matched ->
+        if not matched and p["role"] == role and p["status"] == "pending" do
+          {%{
+             p
+             | "status" => "complete",
+               "file" => filename,
+               "completed_at" => now_iso8601(),
+               "usage" => normalize_usage(usage)
+           }, true}
         else
-          p
+          {p, matched}
         end
       end)
 

--- a/lib/thinktank/output.ex
+++ b/lib/thinktank/output.ex
@@ -104,10 +104,19 @@ defmodule Thinktank.Output do
     })
   end
 
+  @type perspective_summary :: %{role: String.t(), status: String.t(), file: String.t() | nil}
+
+  @type envelope :: %{
+          output_dir: Path.t(),
+          status: String.t(),
+          perspectives: [perspective_summary()],
+          files: [String.t()]
+        }
+
   @doc """
   Build a result envelope for `--json` stdout output.
   """
-  @spec result_envelope(Path.t()) :: map()
+  @spec result_envelope(Path.t()) :: envelope()
   def result_envelope(output_dir) do
     manifest = read_manifest(output_dir)
 

--- a/lib/thinktank/router.ex
+++ b/lib/thinktank/router.ex
@@ -140,6 +140,7 @@ defmodule Thinktank.Router do
   end
 
   @doc false
+  @spec default_perspectives([String.t()]) :: [Perspective.t()]
   def default_perspectives(available_models) do
     available_models
     |> Enum.with_index()

--- a/lib/thinktank/router.ex
+++ b/lib/thinktank/router.ex
@@ -10,9 +10,7 @@ defmodule Thinktank.Router do
   if the router call fails or returns no valid perspectives.
   """
 
-  alias Thinktank.{OpenRouter, Perspective}
-
-  @router_model "google/gemini-3-flash-preview"
+  alias Thinktank.{Models, OpenRouter, Perspective}
 
   @perspective_item_schema %{
     "type" => "object",
@@ -58,10 +56,11 @@ defmodule Thinktank.Router do
   Options:
     - `:available_models` — list of model IDs the router may assign (required, non-empty)
     - `:perspectives` — target count (default 4)
+    - `:tier` — model tier for the router call (default `:standard`)
     - `:openrouter_opts` — keyword opts forwarded to `OpenRouter.chat_structured/5`
   """
   @spec generate_perspectives(String.t(), [String.t()], keyword()) ::
-          {:ok, [Perspective.t()]} | {:error, :no_models}
+          {:ok, [Perspective.t()], OpenRouter.usage() | nil} | {:error, :no_models}
   def generate_perspectives(_instruction, _file_paths, opts \\ [])
 
   def generate_perspectives(_instruction, _file_paths, opts)
@@ -81,19 +80,21 @@ defmodule Thinktank.Router do
 
   defp do_generate(instruction, file_paths, available, opts) do
     count = Keyword.get(opts, :perspectives, 4)
+    tier = Keyword.get(opts, :tier, :standard)
     or_opts = Keyword.get(opts, :openrouter_opts, [])
+    router_model = Models.router_model(tier)
 
     system = system_prompt()
     user = user_prompt(instruction, file_paths, available, count)
 
     case OpenRouter.chat_structured(
-           @router_model,
+           router_model,
            system,
            user,
            perspective_schema(count),
            or_opts
          ) do
-      {:ok, %{"perspectives" => raw}} when is_list(raw) ->
+      {:ok, %{"perspectives" => raw}, usage} when is_list(raw) ->
         perspectives =
           raw
           |> Enum.map(&Perspective.from_map/1)
@@ -101,16 +102,16 @@ defmodule Thinktank.Router do
           |> Enum.filter(&(&1.model in available))
 
         if perspectives == [] do
-          {:ok, default_perspectives(available)}
+          {:ok, default_perspectives(available), nil}
         else
-          {:ok, perspectives}
+          {:ok, perspectives, usage}
         end
 
-      {:ok, _} ->
-        {:ok, default_perspectives(available)}
+      {:ok, _, _usage} ->
+        {:ok, default_perspectives(available), nil}
 
       {:error, _} ->
-        {:ok, default_perspectives(available)}
+        {:ok, default_perspectives(available), nil}
     end
   end
 

--- a/lib/thinktank/router.ex
+++ b/lib/thinktank/router.ex
@@ -102,13 +102,13 @@ defmodule Thinktank.Router do
           |> Enum.filter(&(&1.model in available))
 
         if perspectives == [] do
-          {:ok, default_perspectives(available), nil}
+          {:ok, default_perspectives(available), usage}
         else
           {:ok, perspectives, usage}
         end
 
-      {:ok, _, _usage} ->
-        {:ok, default_perspectives(available), nil}
+      {:ok, _, usage} ->
+        {:ok, default_perspectives(available), usage}
 
       {:error, _} ->
         {:ok, default_perspectives(available), nil}

--- a/lib/thinktank/synthesis.ex
+++ b/lib/thinktank/synthesis.ex
@@ -10,10 +10,8 @@ defmodule Thinktank.Synthesis do
   Retries up to 3 times with exponential backoff on failure.
   """
 
-  alias Thinktank.OpenRouter
+  alias Thinktank.{Models, OpenRouter}
 
-  # Strong reasoning, 1M context, $2/$12 per M — verified via OpenRouter API
-  @default_model "google/gemini-3.1-pro-preview"
   @max_attempts 3
   @default_backoff_base 1000
 
@@ -37,24 +35,22 @@ defmodule Thinktank.Synthesis do
   Actionable next steps, grounded in the evidence from perspectives. Prioritize by impact.\
   """
 
-  @doc "The default synthesis model."
-  @spec default_model() :: String.t()
-  def default_model, do: @default_model
-
   @doc """
   Synthesize perspective outputs into structured insight.
 
   Takes a list of `{role, text}` tuples and the original instruction.
 
   Options:
-    - `:synthesis_model` — model to use (defaults to `#{@default_model}`)
+    - `:synthesis_model` — explicit model override
+    - `:tier` — model tier (default `:standard`), used when no `:synthesis_model` given
     - `:openrouter_opts` — keyword opts forwarded to `OpenRouter.chat/4`
     - `:backoff_base` — base backoff in ms (default 1000, set low in tests)
   """
   @spec synthesize([{String.t(), String.t()}], String.t(), keyword()) ::
-          {:ok, String.t()} | {:error, map()}
+          {:ok, String.t(), OpenRouter.usage()} | {:error, map()}
   def synthesize(perspectives, instruction, opts \\ []) do
-    model = opts[:synthesis_model] || @default_model
+    tier = Keyword.get(opts, :tier, :standard)
+    model = opts[:synthesis_model] || Models.synthesis_model(tier)
     or_opts = opts[:openrouter_opts] || []
     backoff_base = opts[:backoff_base] || @default_backoff_base
     user_prompt = build_user_prompt(perspectives, instruction)
@@ -68,8 +64,8 @@ defmodule Thinktank.Synthesis do
 
   defp retry(model, prompt, or_opts, backoff_base, attempt) do
     case OpenRouter.chat(model, @system_prompt, prompt, or_opts) do
-      {:ok, _text} = ok ->
-        ok
+      {:ok, text, usage} ->
+        {:ok, text, usage}
 
       {:error, _} = err ->
         if attempt < @max_attempts do

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Thinktank.MixProject do
       deps: deps(),
       escript: escript(),
       dialyzer: [plt_add_apps: [:mix]],
-      test_coverage: [tool: ExCoveralls]
+      test_coverage: [tool: ExCoveralls, summary: [threshold: 80]]
     ]
   end
 

--- a/scripts/validate-elixir-models.sh
+++ b/scripts/validate-elixir-models.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Extract model ID strings from Elixir source files
-PROVIDERS="anthropic\|openai\|google\|deepseek\|meta-llama\|mistralai\|qwen\|moonshotai"
+PROVIDERS="anthropic\|openai\|google\|deepseek\|meta-llama\|mistralai\|qwen\|moonshotai\|nvidia\|bytedance-seed\|inception\|x-ai"
 ELIXIR_MODELS=$(grep -rho "\"\\(${PROVIDERS}\\)/[a-z0-9._-]*\"" \
   "$REPO_ROOT/lib/" \
   2>/dev/null \

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -99,6 +99,10 @@ defmodule Thinktank.CLITest do
       assert opts.tier == :cheap
     end
 
+    test "returns error for invalid tier" do
+      assert {:error, "invalid tier: bogus" <> _} = CLI.parse_args(["test", "--tier", "bogus"])
+    end
+
     test "parses --dry-run flag" do
       {:ok, opts} = CLI.parse_args(["test", "--dry-run"])
       assert opts.dry_run == true

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -79,6 +79,26 @@ defmodule Thinktank.CLITest do
       assert opts.perspectives == 4
     end
 
+    test "defaults tier to standard" do
+      {:ok, opts} = CLI.parse_args(["test"])
+      assert opts.tier == :standard
+    end
+
+    test "parses --tier cheap" do
+      {:ok, opts} = CLI.parse_args(["test", "--tier", "cheap"])
+      assert opts.tier == :cheap
+    end
+
+    test "parses --tier premium" do
+      {:ok, opts} = CLI.parse_args(["test", "--tier", "premium"])
+      assert opts.tier == :premium
+    end
+
+    test "parses -t alias for tier" do
+      {:ok, opts} = CLI.parse_args(["test", "-t", "cheap"])
+      assert opts.tier == :cheap
+    end
+
     test "parses --dry-run flag" do
       {:ok, opts} = CLI.parse_args(["test", "--dry-run"])
       assert opts.dry_run == true
@@ -137,6 +157,7 @@ defmodule Thinktank.CLITest do
       assert is_list(decoded["models"])
       assert is_list(decoded["roles"])
       assert is_boolean(decoded["no_synthesis"])
+      assert decoded["tier"] == "standard"
     end
 
     test "paths are included when provided" do

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -111,14 +111,58 @@ defmodule Thinktank.CLITest do
     end
   end
 
-  describe "dry_run JSON output" do
-    test "produces valid JSON envelope" do
+  describe "parse_args/1 — edge cases" do
+    test "empty models string parses to single empty string" do
+      {:ok, opts} = CLI.parse_args(["test", "--models", ""])
+      assert opts.models == [""]
+    end
+
+    test "--deep flag explicitly sets deep mode" do
+      {:ok, opts} = CLI.parse_args(["test", "--deep"])
+      assert opts.mode == :deep
+    end
+  end
+
+  describe "dry_run_output/1" do
+    test "produces valid JSON with all expected fields" do
       {:ok, opts} = CLI.parse_args(["test instruction", "--dry-run", "--json"])
       json = CLI.dry_run_output(opts)
       assert {:ok, decoded} = Jason.decode(json)
+
       assert decoded["mode"] == "dry_run"
       assert decoded["instruction"] == "test instruction"
       assert is_list(decoded["paths"])
+      assert is_integer(decoded["perspectives"])
+      assert is_binary(decoded["dispatch_mode"])
+      assert is_list(decoded["models"])
+      assert is_list(decoded["roles"])
+      assert is_boolean(decoded["no_synthesis"])
+    end
+
+    test "paths are included when provided" do
+      {:ok, opts} = CLI.parse_args(["test", "--dry-run", "--paths", "./src"])
+      json = CLI.dry_run_output(opts)
+      decoded = Jason.decode!(json)
+
+      assert decoded["paths"] == [Path.expand("./src")]
+    end
+
+    test "models and roles are included when provided" do
+      {:ok, opts} =
+        CLI.parse_args([
+          "test",
+          "--dry-run",
+          "--models",
+          "model-a,model-b",
+          "--roles",
+          "auditor,reviewer"
+        ])
+
+      json = CLI.dry_run_output(opts)
+      decoded = Jason.decode!(json)
+
+      assert decoded["models"] == ["model-a", "model-b"]
+      assert decoded["roles"] == ["auditor", "reviewer"]
     end
   end
 end

--- a/test/thinktank/dispatch/deep_test.exs
+++ b/test/thinktank/dispatch/deep_test.exs
@@ -129,7 +129,7 @@ defmodule Thinktank.Dispatch.DeepTest do
       Deep.dispatch(perspectives, "review code", runner: runner)
 
       assert_receive {:call, "sh", ["-c", shell_cmd], _opts}
-      assert shell_cmd =~ "pi --no-session --no-skills"
+      assert shell_cmd =~ "exec pi --no-session --no-skills"
       assert shell_cmd =~ "--model 'anthropic/claude-opus-4-6'"
       assert shell_cmd =~ "--tools read,bash,grep,find"
       assert shell_cmd =~ "< /dev/null"

--- a/test/thinktank/dispatch/deep_test.exs
+++ b/test/thinktank/dispatch/deep_test.exs
@@ -47,7 +47,7 @@ defmodule Thinktank.Dispatch.DeepTest do
       runner = fn _cmd, _args, _opts -> {"## Security Analysis\nAll clear.", 0} end
 
       [result] = Deep.dispatch(perspectives, "audit this", runner: runner)
-      assert {:ok, "security", "## Security Analysis\nAll clear."} = result
+      assert {:ok, "security", "## Security Analysis\nAll clear.", nil} = result
     end
 
     test "returns {:error, role, error_map} for crashed agents" do
@@ -81,7 +81,7 @@ defmodule Thinktank.Dispatch.DeepTest do
       results = Deep.dispatch(perspectives, "test", runner: runner)
 
       assert length(results) == 3
-      oks = Enum.filter(results, &match?({:ok, _, _}, &1))
+      oks = Enum.filter(results, &match?({:ok, _, _, _}, &1))
       errors = Enum.filter(results, &match?({:error, _, _}, &1))
       assert length(oks) == 2
       assert length(errors) == 1

--- a/test/thinktank/dispatch/deep_test.exs
+++ b/test/thinktank/dispatch/deep_test.exs
@@ -293,6 +293,83 @@ defmodule Thinktank.Dispatch.DeepTest do
       assert shell_cmd =~ "You'\\''re an expert."
       assert shell_cmd =~ "what'\\''s the issue?"
     end
+
+    test "passes through backticks in prompt" do
+      perspectives = [
+        %Perspective{role: "test", model: "m", system_prompt: "Check `main` function."}
+      ]
+
+      test_pid = self()
+
+      runner = fn _cmd, args, _opts ->
+        send(test_pid, {:args, args})
+        {"done", 0}
+      end
+
+      Deep.dispatch(perspectives, "review `lib/app.ex`", runner: runner)
+
+      assert_receive {:args, ["-c", shell_cmd]}
+      assert shell_cmd =~ "`main`"
+      assert shell_cmd =~ "`lib/app.ex`"
+    end
+
+    test "passes through dollar signs (single-quoted)" do
+      perspectives = [
+        %Perspective{role: "test", model: "m", system_prompt: "Check $HOME variable."}
+      ]
+
+      test_pid = self()
+
+      runner = fn _cmd, args, _opts ->
+        send(test_pid, {:args, args})
+        {"done", 0}
+      end
+
+      Deep.dispatch(perspectives, "expand $PATH", runner: runner)
+
+      assert_receive {:args, ["-c", shell_cmd]}
+      assert shell_cmd =~ "$HOME"
+      assert shell_cmd =~ "$PATH"
+    end
+
+    test "preserves newlines in prompt" do
+      system = "Line one.\nLine two.\nLine three."
+
+      perspectives = [
+        %Perspective{role: "test", model: "m", system_prompt: system}
+      ]
+
+      test_pid = self()
+
+      runner = fn _cmd, args, _opts ->
+        send(test_pid, {:args, args})
+        {"done", 0}
+      end
+
+      Deep.dispatch(perspectives, "go", runner: runner)
+
+      assert_receive {:args, ["-c", shell_cmd]}
+      assert shell_cmd =~ "Line one.\nLine two.\nLine three."
+    end
+
+    test "handles empty prompt" do
+      perspectives = [
+        %Perspective{role: "test", model: "m", system_prompt: ""}
+      ]
+
+      test_pid = self()
+
+      runner = fn _cmd, args, _opts ->
+        send(test_pid, {:args, args})
+        {"done", 0}
+      end
+
+      Deep.dispatch(perspectives, "", runner: runner)
+
+      assert_receive {:args, ["-c", shell_cmd]}
+      assert shell_cmd =~ "--model 'm'"
+      assert shell_cmd =~ "-p '"
+    end
   end
 
   # Flush all messages with a given tag, collecting the payloads

--- a/test/thinktank/dispatch/deep_test.exs
+++ b/test/thinktank/dispatch/deep_test.exs
@@ -12,6 +12,9 @@ defmodule Thinktank.Dispatch.DeepTest do
     }
   end
 
+  # Extract the shell command string from runner args (sh -c "...")
+  defp shell_cmd(["-c", cmd]), do: cmd
+
   describe "dispatch/3 — parallel subprocess spawning" do
     test "spawns one subprocess per perspective and returns results" do
       perspectives = [
@@ -31,9 +34,11 @@ defmodule Thinktank.Dispatch.DeepTest do
 
       assert length(results) == 3
 
-      # Verify 3 subprocesses were spawned
       spawns = flush_tagged(:spawned)
       assert length(spawns) == 3
+
+      # All spawns go through sh
+      Enum.each(spawns, fn {cmd, _args, _opts} -> assert cmd == "sh" end)
     end
 
     test "returns {:ok, role, text} for successful agents" do
@@ -64,15 +69,10 @@ defmodule Thinktank.Dispatch.DeepTest do
       ]
 
       runner = fn _cmd, args, _opts ->
-        if "--model" in args do
-          model_idx = Enum.find_index(args, &(&1 == "--model"))
-          model = Enum.at(args, model_idx + 1)
+        cmd = shell_cmd(args)
 
-          if model == "model-b" do
-            {"crash", 137}
-          else
-            {"ok", 0}
-          end
+        if cmd =~ "model-b" do
+          {"crash", 137}
         else
           {"ok", 0}
         end
@@ -117,7 +117,7 @@ defmodule Thinktank.Dispatch.DeepTest do
   end
 
   describe "dispatch/3 — command arguments" do
-    test "passes correct pi args with model and tools" do
+    test "wraps pi via sh -c with correct flags" do
       perspectives = [perspective("analyst", "anthropic/claude-opus-4-6")]
       test_pid = self()
 
@@ -128,17 +128,11 @@ defmodule Thinktank.Dispatch.DeepTest do
 
       Deep.dispatch(perspectives, "review code", runner: runner)
 
-      assert_receive {:call, "pi", args, _opts}
-      assert "--no-session" in args
-      assert "--no-skills" in args
-      assert "--model" in args
-
-      model_idx = Enum.find_index(args, &(&1 == "--model"))
-      assert Enum.at(args, model_idx + 1) == "anthropic/claude-opus-4-6"
-
-      assert "--tools" in args
-      tools_idx = Enum.find_index(args, &(&1 == "--tools"))
-      assert Enum.at(args, tools_idx + 1) == "read,bash,grep,find"
+      assert_receive {:call, "sh", ["-c", shell_cmd], _opts}
+      assert shell_cmd =~ "pi --no-session --no-skills"
+      assert shell_cmd =~ "--model 'anthropic/claude-opus-4-6'"
+      assert shell_cmd =~ "--tools read,bash,grep,find"
+      assert shell_cmd =~ "< /dev/null"
     end
 
     test "includes instruction and system prompt in the prompt argument" do
@@ -159,12 +153,10 @@ defmodule Thinktank.Dispatch.DeepTest do
 
       Deep.dispatch(perspectives, "audit the auth module", runner: runner)
 
-      assert_receive {:args, args}
-      prompt_idx = Enum.find_index(args, &(&1 == "-p"))
-      prompt = Enum.at(args, prompt_idx + 1)
+      assert_receive {:args, ["-c", shell_cmd]}
 
-      assert prompt =~ "You are a security expert focused on auth."
-      assert prompt =~ "audit the auth module"
+      assert shell_cmd =~ "You are a security expert focused on auth."
+      assert shell_cmd =~ "audit the auth module"
     end
 
     test "includes file paths in the prompt when provided" do
@@ -181,12 +173,10 @@ defmodule Thinktank.Dispatch.DeepTest do
         paths: ["/src/auth.ex", "/src/router.ex"]
       )
 
-      assert_receive {:args, args}
-      prompt_idx = Enum.find_index(args, &(&1 == "-p"))
-      prompt = Enum.at(args, prompt_idx + 1)
+      assert_receive {:args, ["-c", shell_cmd]}
 
-      assert prompt =~ "/src/auth.ex"
-      assert prompt =~ "/src/router.ex"
+      assert shell_cmd =~ "/src/auth.ex"
+      assert shell_cmd =~ "/src/router.ex"
     end
 
     test "sets PI_CODING_AGENT_DIR env when agent_config_dir provided" do
@@ -263,11 +253,8 @@ defmodule Thinktank.Dispatch.DeepTest do
       test_pid = self()
 
       runner = fn _cmd, args, _opts ->
-        model_idx = Enum.find_index(args, &(&1 == "--model"))
-        model = Enum.at(args, model_idx + 1)
-        prompt_idx = Enum.find_index(args, &(&1 == "-p"))
-        prompt = Enum.at(args, prompt_idx + 1)
-        send(test_pid, {:agent, model, prompt})
+        cmd = shell_cmd(args)
+        send(test_pid, {:agent, cmd})
         {"done", 0}
       end
 
@@ -276,15 +263,35 @@ defmodule Thinktank.Dispatch.DeepTest do
       agents = flush_tagged(:agent)
       assert length(agents) == 3
 
-      models = Enum.map(agents, fn {model, _prompt} -> model end)
-      assert "model-a" in models
-      assert "model-b" in models
-      assert "model-c" in models
+      assert Enum.any?(agents, &(&1 =~ "model-a" and &1 =~ "security expert"))
+      assert Enum.any?(agents, &(&1 =~ "model-b" and &1 =~ "performance analyst"))
+      assert Enum.any?(agents, &(&1 =~ "model-c" and &1 =~ "software architect"))
+    end
+  end
 
-      prompts = Enum.map(agents, fn {_model, prompt} -> prompt end)
-      assert Enum.any?(prompts, &(&1 =~ "security expert"))
-      assert Enum.any?(prompts, &(&1 =~ "performance analyst"))
-      assert Enum.any?(prompts, &(&1 =~ "software architect"))
+  describe "build_shell_cmd/2 — shell escaping" do
+    test "escapes single quotes in prompts" do
+      perspectives = [
+        %Perspective{
+          role: "test",
+          model: "test-model",
+          system_prompt: "You're an expert."
+        }
+      ]
+
+      test_pid = self()
+
+      runner = fn _cmd, args, _opts ->
+        send(test_pid, {:args, args})
+        {"done", 0}
+      end
+
+      Deep.dispatch(perspectives, "what's the issue?", runner: runner)
+
+      assert_receive {:args, ["-c", shell_cmd]}
+      # Single quotes should be escaped
+      assert shell_cmd =~ "You'\\''re an expert."
+      assert shell_cmd =~ "what'\\''s the issue?"
     end
   end
 

--- a/test/thinktank/dispatch/quick_test.exs
+++ b/test/thinktank/dispatch/quick_test.exs
@@ -21,7 +21,9 @@ defmodule Thinktank.Dispatch.QuickTest do
     %{"model" => model} = Jason.decode!(body)
 
     Req.Test.json(conn, %{
-      "choices" => [%{"message" => %{"content" => "Response from #{model}"}}]
+      "choices" => [%{"message" => %{"content" => "Response from #{model}"}}],
+      "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+      "cost" => 0.001
     })
   end
 
@@ -30,7 +32,9 @@ defmodule Thinktank.Dispatch.QuickTest do
     %{"messages" => [_, %{"content" => user_prompt}]} = Jason.decode!(body)
 
     Req.Test.json(conn, %{
-      "choices" => [%{"message" => %{"content" => user_prompt}}]
+      "choices" => [%{"message" => %{"content" => user_prompt}}],
+      "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+      "cost" => 0.001
     })
   end
 
@@ -48,10 +52,10 @@ defmodule Thinktank.Dispatch.QuickTest do
       results = Quick.dispatch(perspectives, "test instruction", openrouter_opts: @or_opts)
 
       assert length(results) == 4
-      assert {:ok, "analyst-1", "Response from model-a"} in results
-      assert {:ok, "analyst-2", "Response from model-b"} in results
-      assert {:ok, "analyst-3", "Response from model-c"} in results
-      assert {:ok, "analyst-4", "Response from model-d"} in results
+      assert Enum.any?(results, &match?({:ok, "analyst-1", "Response from model-a", _}, &1))
+      assert Enum.any?(results, &match?({:ok, "analyst-2", "Response from model-b", _}, &1))
+      assert Enum.any?(results, &match?({:ok, "analyst-3", "Response from model-c", _}, &1))
+      assert Enum.any?(results, &match?({:ok, "analyst-4", "Response from model-d", _}, &1))
     end
 
     test "sends only instruction when no paths provided" do
@@ -64,7 +68,7 @@ defmodule Thinktank.Dispatch.QuickTest do
           openrouter_opts: @or_opts
         )
 
-      assert {:ok, "analyst", "what do you think?"} = result
+      assert {:ok, "analyst", "what do you think?", _usage} = result
     end
 
     test "inlines file contents in prompt when paths provided", %{tmp_dir: tmp} do
@@ -81,7 +85,7 @@ defmodule Thinktank.Dispatch.QuickTest do
           openrouter_opts: @or_opts
         )
 
-      assert {:ok, "analyst", content} = result
+      assert {:ok, "analyst", content, _usage} = result
       assert content =~ "review this"
       assert content =~ "defmodule Main"
     end
@@ -103,7 +107,9 @@ defmodule Thinktank.Dispatch.QuickTest do
           |> Req.Test.json(%{"error" => %{"message" => "boom"}})
         else
           Req.Test.json(conn, %{
-            "choices" => [%{"message" => %{"content" => "ok"}}]
+            "choices" => [%{"message" => %{"content" => "ok"}}],
+            "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+            "cost" => 0.001
           })
         end
       end)
@@ -111,7 +117,7 @@ defmodule Thinktank.Dispatch.QuickTest do
       results = Quick.dispatch(perspectives, "test", openrouter_opts: @or_opts)
 
       assert length(results) == 3
-      oks = Enum.filter(results, &match?({:ok, _, _}, &1))
+      oks = Enum.filter(results, &match?({:ok, _, _, _}, &1))
       errors = Enum.filter(results, &match?({:error, _, _}, &1))
       assert length(oks) == 2
       assert length(errors) == 1
@@ -143,7 +149,9 @@ defmodule Thinktank.Dispatch.QuickTest do
         send(test_pid, {:system_prompt, sys})
 
         Req.Test.json(conn, %{
-          "choices" => [%{"message" => %{"content" => "ok"}}]
+          "choices" => [%{"message" => %{"content" => "ok"}}],
+          "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+          "cost" => 0.001
         })
       end)
 
@@ -172,7 +180,7 @@ defmodule Thinktank.Dispatch.QuickTest do
           openrouter_opts: @or_opts
         )
 
-      assert {:ok, _, content} = result
+      assert {:ok, _, content, _usage} = result
       assert content =~ "small content"
       refute content =~ String.duplicate("x", 100)
     end
@@ -190,7 +198,7 @@ defmodule Thinktank.Dispatch.QuickTest do
           openrouter_opts: @or_opts
         )
 
-      assert {:ok, _, "review"} = result
+      assert {:ok, _, "review", _usage} = result
     end
   end
 

--- a/test/thinktank/models_test.exs
+++ b/test/thinktank/models_test.exs
@@ -6,34 +6,15 @@ defmodule Thinktank.ModelsTest do
   @tiers [:cheap, :standard, :premium]
 
   describe "models_for_tier/1" do
-    test "returns correct models for cheap tier" do
-      models = Models.models_for_tier(:cheap)
-      assert "qwen/qwen3.5-9b" in models
-      assert "nvidia/nemotron-3-nano-30b-a3b" in models
-      assert "bytedance-seed/seed-2.0-mini" in models
-      assert "qwen/qwen3.5-flash-02-23" in models
-      assert length(models) == 4
-    end
+    test "every tier returns a non-empty list of model ID strings" do
+      for tier <- @tiers do
+        models = Models.models_for_tier(tier)
+        assert is_list(models) and models != [], "#{tier} tier must have models"
+        assert Enum.all?(models, &is_binary/1), "#{tier} models must be strings"
 
-    test "returns correct models for standard tier" do
-      models = Models.models_for_tier(:standard)
-      assert "deepseek/deepseek-v3.2" in models
-      assert "x-ai/grok-4.1-fast" in models
-      assert "inception/mercury-2" in models
-      assert "google/gemini-3-flash-preview" in models
-      assert "mistralai/mistral-large-2512" in models
-      assert "anthropic/claude-haiku-4.5" in models
-      assert length(models) == 6
-    end
-
-    test "returns correct models for premium tier" do
-      models = Models.models_for_tier(:premium)
-      assert "google/gemini-3.1-pro-preview" in models
-      assert "openai/gpt-5.4" in models
-      assert "anthropic/claude-sonnet-4.6" in models
-      assert "x-ai/grok-4.20-beta" in models
-      assert "anthropic/claude-opus-4.6" in models
-      assert length(models) == 5
+        assert Enum.all?(models, &String.contains?(&1, "/")),
+               "#{tier} models must be provider/name format"
+      end
     end
   end
 
@@ -51,29 +32,21 @@ defmodule Thinktank.ModelsTest do
   end
 
   describe "router_model/1" do
-    test "returns valid model ID per tier" do
-      assert Models.router_model(:cheap) == "qwen/qwen3.5-flash-02-23"
-      assert Models.router_model(:standard) == "google/gemini-3-flash-preview"
-      assert Models.router_model(:premium) == "google/gemini-3.1-pro-preview"
-    end
-
-    test "router model exists in its tier" do
+    test "router model exists in its own tier" do
       for tier <- @tiers do
-        assert Models.router_model(tier) in Models.models_for_tier(tier)
+        model = Models.router_model(tier)
+        assert is_binary(model)
+        assert model in Models.models_for_tier(tier)
       end
     end
   end
 
   describe "synthesis_model/1" do
-    test "returns valid model ID per tier" do
-      assert Models.synthesis_model(:cheap) == "qwen/qwen3.5-flash-02-23"
-      assert Models.synthesis_model(:standard) == "google/gemini-3-flash-preview"
-      assert Models.synthesis_model(:premium) == "google/gemini-3.1-pro-preview"
-    end
-
-    test "synthesis model exists in its tier" do
+    test "synthesis model exists in its own tier" do
       for tier <- @tiers do
-        assert Models.synthesis_model(tier) in Models.models_for_tier(tier)
+        model = Models.synthesis_model(tier)
+        assert is_binary(model)
+        assert model in Models.models_for_tier(tier)
       end
     end
   end

--- a/test/thinktank/models_test.exs
+++ b/test/thinktank/models_test.exs
@@ -1,0 +1,100 @@
+defmodule Thinktank.ModelsTest do
+  use ExUnit.Case, async: true
+
+  alias Thinktank.Models
+
+  @tiers [:cheap, :standard, :premium]
+
+  describe "models_for_tier/1" do
+    test "returns correct models for cheap tier" do
+      models = Models.models_for_tier(:cheap)
+      assert "qwen/qwen3.5-9b" in models
+      assert "nvidia/nemotron-3-nano-30b-a3b" in models
+      assert "bytedance-seed/seed-2.0-mini" in models
+      assert "qwen/qwen3.5-flash-02-23" in models
+      assert length(models) == 4
+    end
+
+    test "returns correct models for standard tier" do
+      models = Models.models_for_tier(:standard)
+      assert "deepseek/deepseek-v3.2" in models
+      assert "x-ai/grok-4.1-fast" in models
+      assert "inception/mercury-2" in models
+      assert "google/gemini-3-flash-preview" in models
+      assert "mistralai/mistral-large-2512" in models
+      assert "anthropic/claude-haiku-4.5" in models
+      assert length(models) == 6
+    end
+
+    test "returns correct models for premium tier" do
+      models = Models.models_for_tier(:premium)
+      assert "google/gemini-3.1-pro-preview" in models
+      assert "openai/gpt-5.4" in models
+      assert "anthropic/claude-sonnet-4.6" in models
+      assert "x-ai/grok-4.20-beta" in models
+      assert "anthropic/claude-opus-4.6" in models
+      assert length(models) == 5
+    end
+  end
+
+  describe "tier_for_model/1" do
+    test "round-trips every model back to its tier" do
+      for tier <- @tiers, model <- Models.models_for_tier(tier) do
+        assert Models.tier_for_model(model) == tier,
+               "expected #{model} to resolve to #{tier}"
+      end
+    end
+
+    test "returns nil for unknown model" do
+      assert Models.tier_for_model("unknown/nonexistent-model") == nil
+    end
+  end
+
+  describe "router_model/1" do
+    test "returns valid model ID per tier" do
+      assert Models.router_model(:cheap) == "qwen/qwen3.5-flash-02-23"
+      assert Models.router_model(:standard) == "google/gemini-3-flash-preview"
+      assert Models.router_model(:premium) == "google/gemini-3.1-pro-preview"
+    end
+
+    test "router model exists in its tier" do
+      for tier <- @tiers do
+        assert Models.router_model(tier) in Models.models_for_tier(tier)
+      end
+    end
+  end
+
+  describe "synthesis_model/1" do
+    test "returns valid model ID per tier" do
+      assert Models.synthesis_model(:cheap) == "qwen/qwen3.5-flash-02-23"
+      assert Models.synthesis_model(:standard) == "google/gemini-3-flash-preview"
+      assert Models.synthesis_model(:premium) == "google/gemini-3.1-pro-preview"
+    end
+
+    test "synthesis model exists in its tier" do
+      for tier <- @tiers do
+        assert Models.synthesis_model(tier) in Models.models_for_tier(tier)
+      end
+    end
+  end
+
+  describe "all_model_ids/0" do
+    test "contains all models from all tiers" do
+      all = Models.all_model_ids()
+
+      for tier <- @tiers, model <- Models.models_for_tier(tier) do
+        assert model in all, "expected #{model} from #{tier} in all_model_ids"
+      end
+    end
+
+    test "has no duplicates" do
+      all = Models.all_model_ids()
+      assert length(all) == length(Enum.uniq(all))
+    end
+
+    test "total count matches sum of tier counts" do
+      expected = Enum.sum(for tier <- @tiers, do: length(Models.models_for_tier(tier)))
+      assert length(Models.all_model_ids()) == expected
+    end
+  end
+end

--- a/test/thinktank/openrouter_test.exs
+++ b/test/thinktank/openrouter_test.exs
@@ -7,7 +7,9 @@ defmodule Thinktank.OpenRouterTest do
 
   defp success_plug(conn) do
     Req.Test.json(conn, %{
-      "choices" => [%{"message" => %{"content" => "Hello from the model"}}]
+      "choices" => [%{"message" => %{"content" => "Hello from the model"}}],
+      "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+      "cost" => 0.00015
     })
   end
 
@@ -15,7 +17,9 @@ defmodule Thinktank.OpenRouterTest do
     Req.Test.json(conn, %{
       "choices" => [
         %{"message" => %{"content" => Jason.encode!(%{"name" => "Alice", "age" => 30})}}
-      ]
+      ],
+      "usage" => %{"prompt_tokens" => 10, "completion_tokens" => 20, "total_tokens" => 30},
+      "cost" => 0.00015
     })
   end
 
@@ -36,15 +40,20 @@ defmodule Thinktank.OpenRouterTest do
     fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       send(test_pid, {:request, conn, body})
-      Req.Test.json(conn, %{"choices" => [%{"message" => %{"content" => "ok"}}]})
+
+      Req.Test.json(conn, %{
+        "choices" => [%{"message" => %{"content" => "ok"}}],
+        "usage" => %{"prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2},
+        "cost" => 0.0001
+      })
     end
   end
 
   describe "chat/4" do
-    test "returns {:ok, text} on success" do
+    test "returns {:ok, text, usage} on success" do
       Req.Test.stub(OpenRouter, &success_plug/1)
 
-      assert {:ok, "Hello from the model"} =
+      assert {:ok, "Hello from the model", _usage} =
                OpenRouter.chat("test-model", "system prompt", "user prompt", @test_opts)
     end
 
@@ -80,7 +89,7 @@ defmodule Thinktank.OpenRouterTest do
   end
 
   describe "chat_structured/5" do
-    test "returns {:ok, parsed_map} on success" do
+    test "returns {:ok, parsed_map, usage} on success" do
       Req.Test.stub(OpenRouter, &structured_plug/1)
 
       schema = %{
@@ -88,7 +97,7 @@ defmodule Thinktank.OpenRouterTest do
         "properties" => %{"name" => %{"type" => "string"}, "age" => %{"type" => "integer"}}
       }
 
-      assert {:ok, %{"name" => "Alice", "age" => 30}} =
+      assert {:ok, %{"name" => "Alice", "age" => 30}, _usage} =
                OpenRouter.chat_structured("test-model", "system", "user", schema, @test_opts)
     end
 
@@ -131,6 +140,33 @@ defmodule Thinktank.OpenRouterTest do
 
       assert {:error, %{category: :api_error, status: 502, message: "Bad Gateway"}} =
                OpenRouter.chat("test-model", "system", "user", @test_opts)
+    end
+  end
+
+  describe "usage extraction" do
+    test "returns usage data from response" do
+      Req.Test.stub(OpenRouter, &success_plug/1)
+
+      assert {:ok, _, usage} =
+               OpenRouter.chat("test-model", "system", "user", @test_opts)
+
+      assert usage.prompt_tokens == 10
+      assert usage.completion_tokens == 20
+      assert usage.total_tokens == 30
+      assert usage.cost == 0.00015
+    end
+
+    test "returns zero usage when usage field is missing" do
+      Req.Test.stub(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "choices" => [%{"message" => %{"content" => "no usage here"}}]
+        })
+      end)
+
+      assert {:ok, "no usage here", usage} =
+               OpenRouter.chat("test-model", "system", "user", @test_opts)
+
+      assert usage == %{prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, cost: 0.0}
     end
   end
 

--- a/test/thinktank/openrouter_test.exs
+++ b/test/thinktank/openrouter_test.exs
@@ -127,6 +127,19 @@ defmodule Thinktank.OpenRouterTest do
       assert {:error, %{category: :invalid_json, raw: nil}} =
                OpenRouter.chat_structured("test-model", "system", "user", %{}, @test_opts)
     end
+
+    test "returns {:error, :invalid_json} when decoded JSON is not a map" do
+      Req.Test.stub(OpenRouter, fn conn ->
+        Req.Test.json(conn, %{
+          "choices" => [%{"message" => %{"content" => "[1, 2, 3]"}}],
+          "usage" => %{"prompt_tokens" => 5, "completion_tokens" => 5, "total_tokens" => 10},
+          "cost" => 0.0001
+        })
+      end)
+
+      assert {:error, %{category: :invalid_json, raw: [1, 2, 3]}} =
+               OpenRouter.chat_structured("test-model", "system", "user", %{}, @test_opts)
+    end
   end
 
   describe "error body handling" do

--- a/test/thinktank/output_test.exs
+++ b/test/thinktank/output_test.exs
@@ -1,16 +1,38 @@
 defmodule Thinktank.OutputTest do
   use ExUnit.Case, async: true
 
-  alias Thinktank.Output
+  alias Thinktank.{Output, Perspective}
 
   @moduletag :tmp_dir
 
-  describe "init_run/2" do
-    test "creates output dir and initial manifest", %{tmp_dir: tmp} do
-      output_dir = Path.join(tmp, "run1")
-      perspectives = ["security-analyst", "performance-engineer", "architect"]
+  # Build Perspective structs from role names for test convenience.
+  # Uses "test-model" and a generic system prompt.
+  defp perspectives(roles) when is_list(roles) do
+    Enum.with_index(roles, fn role, i ->
+      %Perspective{
+        role: role,
+        model: "test-model-#{rem(i, 2)}",
+        system_prompt: "You are a #{role}.",
+        priority: i + 1
+      }
+    end)
+  end
 
-      assert :ok = Output.init_run(output_dir, perspectives)
+  defp usage(prompt \\ 10, completion \\ 20, cost \\ 0.001) do
+    %{
+      prompt_tokens: prompt,
+      completion_tokens: completion,
+      total_tokens: prompt + completion,
+      cost: cost
+    }
+  end
+
+  describe "init_run/3" do
+    test "creates output dir and manifest with full perspective config", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "run1")
+      persp = perspectives(["security-analyst", "performance-engineer", "architect"])
+
+      assert :ok = Output.init_run(output_dir, persp, nil)
       assert File.dir?(output_dir)
 
       manifest = read_manifest(output_dir)
@@ -20,37 +42,95 @@ defmodule Thinktank.OutputTest do
       for p <- manifest["perspectives"] do
         assert p["status"] == "pending"
         assert is_nil(p["file"])
+        assert is_binary(p["model"])
+        assert is_binary(p["system_prompt"])
+        assert is_integer(p["priority"])
       end
+    end
+
+    test "manifest records model and system_prompt per perspective", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "run1b")
+
+      persp = [
+        %Perspective{
+          role: "auditor",
+          model: "anthropic/claude-sonnet-4.6",
+          system_prompt: "You are a security auditor.",
+          priority: 1
+        },
+        %Perspective{
+          role: "architect",
+          model: "openai/gpt-5.4",
+          system_prompt: "You are a software architect.",
+          priority: 2
+        }
+      ]
+
+      Output.init_run(output_dir, persp, nil)
+      manifest = read_manifest(output_dir)
+
+      auditor = Enum.find(manifest["perspectives"], &(&1["role"] == "auditor"))
+      assert auditor["model"] == "anthropic/claude-sonnet-4.6"
+      assert auditor["system_prompt"] == "You are a security auditor."
+      assert auditor["priority"] == 1
+
+      architect = Enum.find(manifest["perspectives"], &(&1["role"] == "architect"))
+      assert architect["model"] == "openai/gpt-5.4"
+      assert architect["system_prompt"] == "You are a software architect."
+      assert architect["priority"] == 2
     end
 
     test "manifest contains run metadata", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "run2")
-      assert :ok = Output.init_run(output_dir, ["analyst"])
+      assert :ok = Output.init_run(output_dir, perspectives(["analyst"]), nil)
 
       manifest = read_manifest(output_dir)
       assert is_binary(manifest["started_at"])
       assert manifest["version"] == Thinktank.MixProject.project()[:version]
+    end
+
+    test "manifest stores router_usage when provided", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "run_ru")
+      router_usage = usage(50, 100, 0.005)
+
+      Output.init_run(output_dir, perspectives(["a"]), router_usage)
+      manifest = read_manifest(output_dir)
+
+      assert manifest["router_usage"]["prompt_tokens"] == 50
+      assert manifest["router_usage"]["completion_tokens"] == 100
+      assert manifest["router_usage"]["total_tokens"] == 150
+      assert manifest["router_usage"]["cost"] == 0.005
+    end
+
+    test "manifest stores null router_usage when nil", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "run_ru_nil")
+
+      Output.init_run(output_dir, perspectives(["a"]), nil)
+      manifest = read_manifest(output_dir)
+
+      assert is_nil(manifest["router_usage"])
     end
   end
 
   describe "write_perspective/4" do
     test "writes perspective file and updates manifest", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "wp1")
-      Output.init_run(output_dir, ["security-analyst", "architect"])
+      Output.init_run(output_dir, perspectives(["security-analyst", "architect"]), nil)
 
       content = "## Security Analysis\n\nNo critical vulnerabilities found."
-      assert :ok = Output.write_perspective(output_dir, "security-analyst", content)
+      assert :ok = Output.write_perspective(output_dir, "security-analyst", content, usage())
 
       # File written
       path = Path.join(output_dir, "security-analyst.md")
       assert File.read!(path) == content
 
-      # Manifest updated
+      # Manifest updated — model preserved
       manifest = read_manifest(output_dir)
       sa = Enum.find(manifest["perspectives"], &(&1["role"] == "security-analyst"))
       assert sa["status"] == "complete"
       assert sa["file"] == "security-analyst.md"
       assert is_binary(sa["completed_at"])
+      assert is_binary(sa["model"])
 
       # Other perspective still pending
       arch = Enum.find(manifest["perspectives"], &(&1["role"] == "architect"))
@@ -59,24 +139,58 @@ defmodule Thinktank.OutputTest do
 
     test "handles multiple completions incrementally", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "wp2")
-      Output.init_run(output_dir, ["a", "b", "c"])
+      Output.init_run(output_dir, perspectives(["a", "b", "c"]), nil)
 
-      Output.write_perspective(output_dir, "a", "content a")
+      Output.write_perspective(output_dir, "a", "content a", usage())
       manifest = read_manifest(output_dir)
       assert manifest["perspectives_completed"] == 1
 
-      Output.write_perspective(output_dir, "b", "content b")
+      Output.write_perspective(output_dir, "b", "content b", usage())
       manifest = read_manifest(output_dir)
       assert manifest["perspectives_completed"] == 2
+    end
+
+    test "manifest includes usage per perspective", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "wp_usage")
+      Output.init_run(output_dir, perspectives(["a", "b"]), nil)
+
+      Output.write_perspective(output_dir, "a", "content a", usage(100, 200, 0.01))
+      Output.write_perspective(output_dir, "b", "content b", usage(50, 80, 0.005))
+
+      manifest = read_manifest(output_dir)
+
+      a = Enum.find(manifest["perspectives"], &(&1["role"] == "a"))
+      assert a["usage"]["prompt_tokens"] == 100
+      assert a["usage"]["completion_tokens"] == 200
+      assert a["usage"]["total_tokens"] == 300
+      assert a["usage"]["cost"] == 0.01
+
+      b = Enum.find(manifest["perspectives"], &(&1["role"] == "b"))
+      assert b["usage"]["prompt_tokens"] == 50
+      assert b["usage"]["completion_tokens"] == 80
+      assert b["usage"]["total_tokens"] == 130
+      assert b["usage"]["cost"] == 0.005
+    end
+
+    test "nil usage stored as null in manifest", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "wp_nil_usage")
+      Output.init_run(output_dir, perspectives(["deep-agent"]), nil)
+
+      Output.write_perspective(output_dir, "deep-agent", "deep content", nil)
+
+      manifest = read_manifest(output_dir)
+      p = Enum.find(manifest["perspectives"], &(&1["role"] == "deep-agent"))
+      assert p["status"] == "complete"
+      assert is_nil(p["usage"])
     end
   end
 
   describe "complete_run/1" do
     test "marks manifest as complete with final counts", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "cr1")
-      Output.init_run(output_dir, ["a", "b"])
-      Output.write_perspective(output_dir, "a", "done")
-      Output.write_perspective(output_dir, "b", "done")
+      Output.init_run(output_dir, perspectives(["a", "b"]), nil)
+      Output.write_perspective(output_dir, "a", "done", usage())
+      Output.write_perspective(output_dir, "b", "done", usage())
 
       assert :ok = Output.complete_run(output_dir)
       manifest = read_manifest(output_dir)
@@ -87,47 +201,93 @@ defmodule Thinktank.OutputTest do
 
     test "marks partial when not all perspectives finished", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "cr2")
-      Output.init_run(output_dir, ["a", "b", "c"])
-      Output.write_perspective(output_dir, "a", "done")
+      Output.init_run(output_dir, perspectives(["a", "b", "c"]), nil)
+      Output.write_perspective(output_dir, "a", "done", usage())
 
       assert :ok = Output.complete_run(output_dir)
       manifest = read_manifest(output_dir)
       assert manifest["status"] == "partial"
       assert manifest["perspectives_completed"] == 1
     end
+
+    test "computes total_cost and total_tokens from all sources", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "cr_totals")
+      router_usage = usage(50, 100, 0.005)
+      Output.init_run(output_dir, perspectives(["a", "b"]), router_usage)
+
+      Output.write_perspective(output_dir, "a", "done", usage(100, 200, 0.01))
+      Output.write_perspective(output_dir, "b", "done", usage(80, 160, 0.008))
+      Output.write_synthesis(output_dir, "synthesis", usage(40, 80, 0.004))
+
+      Output.complete_run(output_dir)
+      manifest = read_manifest(output_dir)
+
+      # 0.005 + 0.01 + 0.008 + 0.004 = 0.027
+      assert_in_delta manifest["total_cost"], 0.027, 0.0001
+      # (50+100) + (100+200) + (80+160) + (40+80) = 150 + 300 + 240 + 120 = 810
+      assert manifest["total_tokens"] == 810
+    end
+
+    test "nil usage handled gracefully in totals", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "cr_nil")
+      Output.init_run(output_dir, perspectives(["a", "b"]), nil)
+
+      Output.write_perspective(output_dir, "a", "done", usage(100, 200, 0.01))
+      Output.write_perspective(output_dir, "b", "done", nil)
+
+      Output.complete_run(output_dir)
+      manifest = read_manifest(output_dir)
+
+      # Only perspective "a" contributes
+      assert_in_delta manifest["total_cost"], 0.01, 0.0001
+      assert manifest["total_tokens"] == 300
+    end
+
+    test "totals without synthesis or router_usage", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "cr_minimal")
+      Output.init_run(output_dir, perspectives(["a"]), nil)
+
+      Output.write_perspective(output_dir, "a", "done", usage(10, 20, 0.001))
+
+      Output.complete_run(output_dir)
+      manifest = read_manifest(output_dir)
+
+      assert_in_delta manifest["total_cost"], 0.001, 0.0001
+      assert manifest["total_tokens"] == 30
+    end
   end
 
   describe "kill safety" do
     test "manifest is valid JSON after each write (atomic rename)", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "ks1")
-      Output.init_run(output_dir, ["a", "b", "c"])
+      Output.init_run(output_dir, perspectives(["a", "b", "c"]), nil)
 
       # After init
       assert {:ok, _} = Jason.decode(File.read!(manifest_path(output_dir)))
 
       # After each write
-      Output.write_perspective(output_dir, "a", "content")
+      Output.write_perspective(output_dir, "a", "content", usage())
       assert {:ok, _} = Jason.decode(File.read!(manifest_path(output_dir)))
 
-      Output.write_perspective(output_dir, "b", "content")
+      Output.write_perspective(output_dir, "b", "content", usage())
       assert {:ok, _} = Jason.decode(File.read!(manifest_path(output_dir)))
     end
 
     test "no tmp file left after write", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "ks2")
-      Output.init_run(output_dir, ["a"])
-      Output.write_perspective(output_dir, "a", "content")
+      Output.init_run(output_dir, perspectives(["a"]), nil)
+      Output.write_perspective(output_dir, "a", "content", usage())
 
       refute File.exists?(manifest_path(output_dir) <> ".tmp")
     end
   end
 
   describe "result_envelope/1" do
-    test "returns structured JSON envelope for --json output", %{tmp_dir: tmp} do
+    test "returns structured envelope with model per perspective", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "re1")
-      Output.init_run(output_dir, ["a", "b"])
-      Output.write_perspective(output_dir, "a", "content a")
-      Output.write_perspective(output_dir, "b", "content b")
+      Output.init_run(output_dir, perspectives(["a", "b"]), nil)
+      Output.write_perspective(output_dir, "a", "content a", usage())
+      Output.write_perspective(output_dir, "b", "content b", usage())
       Output.complete_run(output_dir)
 
       envelope = Output.result_envelope(output_dir)
@@ -135,18 +295,31 @@ defmodule Thinktank.OutputTest do
       assert envelope.status == "complete"
       assert length(envelope.perspectives) == 2
       assert Enum.all?(envelope.perspectives, &(&1.status == "complete"))
+      assert Enum.all?(envelope.perspectives, &is_binary(&1.model))
       assert length(envelope.files) == 2
+    end
+
+    test "includes total_cost and total_tokens", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "re_cost")
+      Output.init_run(output_dir, perspectives(["a"]), usage(50, 100, 0.005))
+      Output.write_perspective(output_dir, "a", "content", usage(100, 200, 0.01))
+      Output.write_synthesis(output_dir, "syn", usage(30, 60, 0.003))
+      Output.complete_run(output_dir)
+
+      envelope = Output.result_envelope(output_dir)
+      assert_in_delta envelope.total_cost, 0.018, 0.0001
+      assert envelope.total_tokens == 540
     end
   end
 
-  describe "write_synthesis/2" do
+  describe "write_synthesis/3" do
     test "writes synthesis file and updates manifest", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "syn1")
-      Output.init_run(output_dir, ["a", "b"])
-      Output.write_perspective(output_dir, "a", "content a")
+      Output.init_run(output_dir, perspectives(["a", "b"]), nil)
+      Output.write_perspective(output_dir, "a", "content a", usage())
 
       synthesis = "## Agreement\nBoth agree.\n## Disagreement\nNone."
-      assert :ok = Output.write_synthesis(output_dir, synthesis)
+      assert :ok = Output.write_synthesis(output_dir, synthesis, usage(40, 80, 0.004))
 
       assert File.read!(Path.join(output_dir, "synthesis.md")) == synthesis
 
@@ -154,15 +327,26 @@ defmodule Thinktank.OutputTest do
       assert manifest["synthesis"]["status"] == "complete"
       assert manifest["synthesis"]["file"] == "synthesis.md"
       assert is_binary(manifest["synthesis"]["completed_at"])
+      assert manifest["synthesis"]["usage"]["prompt_tokens"] == 40
+      assert manifest["synthesis"]["usage"]["cost"] == 0.004
+    end
+
+    test "nil usage stored as null in synthesis manifest entry", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "syn_nil")
+      Output.init_run(output_dir, perspectives(["a"]), nil)
+
+      Output.write_synthesis(output_dir, "content", nil)
+      manifest = read_manifest(output_dir)
+      assert is_nil(manifest["synthesis"]["usage"])
     end
   end
 
   describe "result_envelope with synthesis" do
     test "includes synthesis in envelope when present", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "re2")
-      Output.init_run(output_dir, ["a"])
-      Output.write_perspective(output_dir, "a", "content a")
-      Output.write_synthesis(output_dir, "synthesis content")
+      Output.init_run(output_dir, perspectives(["a"]), nil)
+      Output.write_perspective(output_dir, "a", "content a", usage())
+      Output.write_synthesis(output_dir, "synthesis content", usage())
       Output.complete_run(output_dir)
 
       envelope = Output.result_envelope(output_dir)
@@ -172,8 +356,8 @@ defmodule Thinktank.OutputTest do
 
     test "omits synthesis from envelope when not present", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "re3")
-      Output.init_run(output_dir, ["a"])
-      Output.write_perspective(output_dir, "a", "content a")
+      Output.init_run(output_dir, perspectives(["a"]), nil)
+      Output.write_perspective(output_dir, "a", "content a", usage())
       Output.complete_run(output_dir)
 
       envelope = Output.result_envelope(output_dir)
@@ -181,18 +365,15 @@ defmodule Thinktank.OutputTest do
     end
   end
 
-  describe "write_perspective/3 — unknown role" do
+  describe "write_perspective/4 — unknown role" do
     test "role not in manifest does not crash, perspectives list unchanged", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "unk1")
-      Output.init_run(output_dir, ["a", "b"])
+      Output.init_run(output_dir, perspectives(["a", "b"]), nil)
 
-      # Write with a role that was never in the manifest
-      assert :ok = Output.write_perspective(output_dir, "unknown-role", "content")
+      assert :ok = Output.write_perspective(output_dir, "unknown-role", "content", nil)
 
-      # File is still written
       assert File.exists?(Path.join(output_dir, "unknown-role.md"))
 
-      # Manifest perspectives list unchanged (no new entries, no crashes)
       manifest = read_manifest(output_dir)
       assert length(manifest["perspectives"]) == 2
       assert Enum.all?(manifest["perspectives"], &(&1["status"] == "pending"))

--- a/test/thinktank/output_test.exs
+++ b/test/thinktank/output_test.exs
@@ -120,15 +120,15 @@ defmodule Thinktank.OutputTest do
       content = "## Security Analysis\n\nNo critical vulnerabilities found."
       assert :ok = Output.write_perspective(output_dir, "security-analyst", content, usage())
 
-      # File written
-      path = Path.join(output_dir, "security-analyst.md")
+      # File written (priority-prefixed)
+      path = Path.join(output_dir, "1-security-analyst.md")
       assert File.read!(path) == content
 
       # Manifest updated — model preserved
       manifest = read_manifest(output_dir)
       sa = Enum.find(manifest["perspectives"], &(&1["role"] == "security-analyst"))
       assert sa["status"] == "complete"
-      assert sa["file"] == "security-analyst.md"
+      assert sa["file"] == "1-security-analyst.md"
       assert is_binary(sa["completed_at"])
       assert is_binary(sa["model"])
 
@@ -365,19 +365,45 @@ defmodule Thinktank.OutputTest do
     end
   end
 
-  describe "write_perspective/4 — unknown role" do
-    test "role not in manifest does not crash, perspectives list unchanged", %{tmp_dir: tmp} do
+  describe "write_perspective/4 — edge cases" do
+    test "unknown role does not crash, perspectives list unchanged", %{tmp_dir: tmp} do
       output_dir = Path.join(tmp, "unk1")
       Output.init_run(output_dir, perspectives(["a", "b"]), nil)
 
       assert :ok = Output.write_perspective(output_dir, "unknown-role", "content", nil)
 
-      assert File.exists?(Path.join(output_dir, "unknown-role.md"))
+      assert File.exists?(Path.join(output_dir, "0-unknown-role.md"))
 
       manifest = read_manifest(output_dir)
       assert length(manifest["perspectives"]) == 2
       assert Enum.all?(manifest["perspectives"], &(&1["status"] == "pending"))
       assert manifest["perspectives_completed"] == 0
+    end
+
+    test "duplicate roles get separate files and independent completion", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "dup1")
+
+      # Two perspectives with the same role but different priorities
+      dupes = [
+        %Perspective{role: "analyst", model: "model-a", system_prompt: "First.", priority: 1},
+        %Perspective{role: "analyst", model: "model-b", system_prompt: "Second.", priority: 2}
+      ]
+
+      Output.init_run(output_dir, dupes, nil)
+
+      Output.write_perspective(output_dir, "analyst", "first output", usage(10, 20, 0.001))
+      manifest = read_manifest(output_dir)
+      assert manifest["perspectives_completed"] == 1
+      assert File.exists?(Path.join(output_dir, "1-analyst.md"))
+
+      Output.write_perspective(output_dir, "analyst", "second output", usage(30, 40, 0.002))
+      manifest = read_manifest(output_dir)
+      assert manifest["perspectives_completed"] == 2
+      assert File.exists?(Path.join(output_dir, "2-analyst.md"))
+
+      # Both files have distinct content
+      assert File.read!(Path.join(output_dir, "1-analyst.md")) == "first output"
+      assert File.read!(Path.join(output_dir, "2-analyst.md")) == "second output"
     end
   end
 

--- a/test/thinktank/output_test.exs
+++ b/test/thinktank/output_test.exs
@@ -181,12 +181,43 @@ defmodule Thinktank.OutputTest do
     end
   end
 
+  describe "write_perspective/3 — unknown role" do
+    test "role not in manifest does not crash, perspectives list unchanged", %{tmp_dir: tmp} do
+      output_dir = Path.join(tmp, "unk1")
+      Output.init_run(output_dir, ["a", "b"])
+
+      # Write with a role that was never in the manifest
+      assert :ok = Output.write_perspective(output_dir, "unknown-role", "content")
+
+      # File is still written
+      assert File.exists?(Path.join(output_dir, "unknown-role.md"))
+
+      # Manifest perspectives list unchanged (no new entries, no crashes)
+      manifest = read_manifest(output_dir)
+      assert length(manifest["perspectives"]) == 2
+      assert Enum.all?(manifest["perspectives"], &(&1["status"] == "pending"))
+      assert manifest["perspectives_completed"] == 0
+    end
+  end
+
   describe "slugify/1" do
     test "converts role names to filesystem-safe slugs" do
       assert Output.slugify("Security Analyst") == "security-analyst"
       assert Output.slugify("performance_engineer") == "performance-engineer"
       assert Output.slugify("AI/ML Expert") == "ai-ml-expert"
       assert Output.slugify("  spaced  out  ") == "spaced-out"
+    end
+
+    test "empty string returns empty string" do
+      assert Output.slugify("") == ""
+    end
+
+    test "unicode characters are stripped" do
+      assert Output.slugify("café résumé") == "caf-r-sum"
+    end
+
+    test "consecutive special chars collapse to single hyphen" do
+      assert Output.slugify("a///b---c   d") == "a-b-c-d"
     end
   end
 

--- a/test/thinktank/router_test.exs
+++ b/test/thinktank/router_test.exs
@@ -279,5 +279,31 @@ defmodule Thinktank.RouterTest do
       assigned = Enum.map(perspectives, & &1.model)
       assert assigned == ["model-1", "model-2", "model-3", "model-1"]
     end
+
+    test "single model is round-robined to all roles" do
+      roles = ["auditor", "reviewer", "architect"]
+      models = ["the-only-model"]
+
+      perspectives = Router.manual_perspectives(roles, models)
+
+      assert length(perspectives) == 3
+      assert Enum.all?(perspectives, &(&1.model == "the-only-model"))
+      assert Enum.map(perspectives, & &1.role) == roles
+    end
+  end
+
+  describe "default_perspectives/1" do
+    test "returns one perspective per model" do
+      models = ["model-a", "model-b", "model-c"]
+      perspectives = Router.default_perspectives(models)
+
+      assert length(perspectives) == 3
+      assert Enum.all?(perspectives, &match?(%Perspective{}, &1))
+      assert Enum.map(perspectives, & &1.model) == models
+    end
+
+    test "returns empty list for empty models" do
+      assert Router.default_perspectives([]) == []
+    end
   end
 end

--- a/test/thinktank/router_test.exs
+++ b/test/thinktank/router_test.exs
@@ -73,7 +73,7 @@ defmodule Thinktank.RouterTest do
     test "returns list of Perspective structs on success" do
       Req.Test.stub(Router, &router_success_plug/1)
 
-      assert {:ok, perspectives} =
+      assert {:ok, perspectives, _usage} =
                Router.generate_perspectives(
                  "Review this codebase",
                  ["lib/app.ex"],
@@ -94,7 +94,7 @@ defmodule Thinktank.RouterTest do
     test "every perspective uses a model from available_models" do
       Req.Test.stub(Router, &router_success_plug/1)
 
-      {:ok, perspectives} =
+      {:ok, perspectives, _usage} =
         Router.generate_perspectives(
           "Review this codebase",
           ["lib/app.ex"],
@@ -111,7 +111,7 @@ defmodule Thinktank.RouterTest do
     test "filters out perspectives with models not in available_models" do
       Req.Test.stub(Router, &invalid_model_plug/1)
 
-      {:ok, perspectives} =
+      {:ok, perspectives, _usage} =
         Router.generate_perspectives(
           "Review this codebase",
           ["lib/app.ex"],
@@ -126,7 +126,7 @@ defmodule Thinktank.RouterTest do
     test "falls back to default council on API error" do
       Req.Test.stub(Router, &error_plug/1)
 
-      {:ok, perspectives} =
+      {:ok, perspectives, usage} =
         Router.generate_perspectives(
           "Review this codebase",
           ["lib/app.ex"],
@@ -135,6 +135,7 @@ defmodule Thinktank.RouterTest do
         )
 
       assert length(perspectives) == length(@available_models)
+      assert usage == nil
 
       models = Enum.map(perspectives, & &1.model)
       assert Enum.sort(models) == Enum.sort(@available_models)
@@ -159,7 +160,7 @@ defmodule Thinktank.RouterTest do
         })
       end)
 
-      {:ok, perspectives} =
+      {:ok, perspectives, _usage} =
         Router.generate_perspectives(
           "Review this codebase",
           ["lib/app.ex"],
@@ -173,7 +174,7 @@ defmodule Thinktank.RouterTest do
     test "handles empty file_paths" do
       Req.Test.stub(Router, &router_success_plug/1)
 
-      assert {:ok, _perspectives} =
+      assert {:ok, _perspectives, _usage} =
                Router.generate_perspectives(
                  "General question",
                  [],
@@ -203,7 +204,7 @@ defmodule Thinktank.RouterTest do
         })
       end)
 
-      {:ok, perspectives} =
+      {:ok, perspectives, _usage} =
         Router.generate_perspectives(
           "Review this",
           ["lib/app.ex"],
@@ -238,7 +239,7 @@ defmodule Thinktank.RouterTest do
         })
       end)
 
-      {:ok, perspectives} =
+      {:ok, perspectives, _usage} =
         Router.generate_perspectives(
           "Review this",
           ["lib/app.ex"],
@@ -248,6 +249,30 @@ defmodule Thinktank.RouterTest do
 
       assert length(perspectives) == 1
       assert hd(perspectives).role == "valid"
+    end
+
+    test "uses tier-based router model" do
+      test_pid = self()
+
+      Req.Test.stub(Router, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:router_model, Jason.decode!(body)["model"]})
+
+        Req.Test.json(conn, %{
+          "choices" => [%{"message" => %{"content" => Jason.encode!(%{"perspectives" => []})}}]
+        })
+      end)
+
+      Router.generate_perspectives(
+        "Review this",
+        ["lib/app.ex"],
+        available_models: @available_models,
+        openrouter_opts: @test_opts,
+        tier: :cheap
+      )
+
+      assert_receive {:router_model, model}
+      assert model == Thinktank.Models.router_model(:cheap)
     end
   end
 

--- a/test/thinktank/synthesis_test.exs
+++ b/test/thinktank/synthesis_test.exs
@@ -171,5 +171,29 @@ defmodule Thinktank.SynthesisTest do
       assert {:ok, "Sparse output"} =
                Synthesis.synthesize(@perspectives, "review this", openrouter_opts: @test_opts)
     end
+
+    test "handles empty perspectives list — still calls the API" do
+      test_pid = self()
+
+      Req.Test.stub(Synthesis, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:called, Jason.decode!(body)})
+        Req.Test.json(conn, %{"choices" => [%{"message" => %{"content" => "synthesized"}}]})
+      end)
+
+      assert {:ok, "synthesized"} =
+               Synthesis.synthesize([], "empty question", openrouter_opts: @test_opts)
+
+      assert_receive {:called, body}
+      assert body["messages"] |> length() == 2
+    end
+  end
+
+  describe "default_model/0" do
+    test "returns a non-empty string" do
+      model = Synthesis.default_model()
+      assert is_binary(model)
+      assert model != ""
+    end
   end
 end

--- a/test/thinktank/synthesis_test.exs
+++ b/test/thinktank/synthesis_test.exs
@@ -45,10 +45,10 @@ defmodule Thinktank.SynthesisTest do
   end
 
   describe "synthesize/3" do
-    test "returns {:ok, text} containing all required sections" do
+    test "returns {:ok, text, usage} containing all required sections" do
       Req.Test.stub(Synthesis, synthesis_response(full_synthesis_text()))
 
-      assert {:ok, text} =
+      assert {:ok, text, _usage} =
                Synthesis.synthesize(@perspectives, "review this auth flow",
                  openrouter_opts: @test_opts
                )
@@ -108,7 +108,7 @@ defmodule Thinktank.SynthesisTest do
         end
       end)
 
-      assert {:ok, _text} =
+      assert {:ok, _text, _usage} =
                Synthesis.synthesize(@perspectives, "review this",
                  openrouter_opts: @test_opts,
                  backoff_base: 1
@@ -150,7 +150,7 @@ defmodule Thinktank.SynthesisTest do
       assert_receive {:model_used, "anthropic/claude-opus-4.6"}
     end
 
-    test "defaults to most capable model when none specified" do
+    test "defaults to standard tier model when none specified" do
       test_pid = self()
 
       Req.Test.stub(Synthesis, fn conn ->
@@ -162,13 +162,13 @@ defmodule Thinktank.SynthesisTest do
       Synthesis.synthesize(@perspectives, "review this", openrouter_opts: @test_opts)
 
       assert_receive {:model_used, model}
-      assert model == Synthesis.default_model()
+      assert model == Thinktank.Models.synthesis_model(:standard)
     end
 
-    test "returns {:ok, text} with whatever the model produces" do
+    test "returns {:ok, text, usage} with whatever the model produces" do
       Req.Test.stub(Synthesis, synthesis_response("Sparse output"))
 
-      assert {:ok, "Sparse output"} =
+      assert {:ok, "Sparse output", _usage} =
                Synthesis.synthesize(@perspectives, "review this", openrouter_opts: @test_opts)
     end
 
@@ -181,7 +181,7 @@ defmodule Thinktank.SynthesisTest do
         Req.Test.json(conn, %{"choices" => [%{"message" => %{"content" => "synthesized"}}]})
       end)
 
-      assert {:ok, "synthesized"} =
+      assert {:ok, "synthesized", _usage} =
                Synthesis.synthesize([], "empty question", openrouter_opts: @test_opts)
 
       assert_receive {:called, body}
@@ -189,11 +189,23 @@ defmodule Thinktank.SynthesisTest do
     end
   end
 
-  describe "default_model/0" do
-    test "returns a non-empty string" do
-      model = Synthesis.default_model()
-      assert is_binary(model)
-      assert model != ""
+  describe "tier-based model selection" do
+    test "uses tier model when no explicit synthesis_model given" do
+      test_pid = self()
+
+      Req.Test.stub(Synthesis, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:model_used, Jason.decode!(body)["model"]})
+        Req.Test.json(conn, %{"choices" => [%{"message" => %{"content" => "ok"}}]})
+      end)
+
+      Synthesis.synthesize(@perspectives, "review this",
+        openrouter_opts: @test_opts,
+        tier: :cheap
+      )
+
+      assert_receive {:model_used, model}
+      assert model == Thinktank.Models.synthesis_model(:cheap)
     end
   end
 end


### PR DESCRIPTION
## Why This Matters

Deep mode was silently broken since the Elixir v5 migration (stdin hang + MuonTrap escript incompatibility). The post-merge auto-rebuild hook was deleted. Model selection was hardcoded to 4 expensive models with no cost tracking.

This PR fixes deep mode, restores the post-merge hook, adds a 3-tier model catalog (cheap/standard/premium), and plumbs usage/cost tracking through the entire pipeline.

## What Changed

### Deep mode fixes
- Pi CLI hangs when Erlang ports keep stdin open — wrapped via `sh -c "exec pi ... < /dev/null"`
- MuonTrap's priv binary unavailable in escripts — `System.cmd` fallback with auto-detection

### Model tiers (`--tier cheap|standard|premium`)
- 15 curated SOTA models across 8 providers (Qwen, NVIDIA, ByteDance, DeepSeek, xAI, Google, Mistral, Anthropic)
- Cheap tier: $0.05-0.10/M tokens. Standard: $0.20-1.00/M. Premium: $2.00-5.00/M
- Router and synthesis models scale with tier
- `--models` still overrides tier when explicit

### Usage/cost tracking
- OpenRouter `usage` + `cost` extracted from every API response
- Per-perspective, router, and synthesis usage recorded in manifest
- `total_cost` and `total_tokens` computed on run completion
- Surfaced in `--json` output envelope

### Quality gates
- Typespecs on all public functions (0 dialyzer errors)
- Dialyzer + hex.audit added to CI with PLT caching
- Credo strict mode in config
- Coverage threshold at 80%

### Post-merge hook
- `lefthook.yml` restored with `mix deps.get && mix escript.build`

## Trade-offs / Risks

- **System.cmd fallback loses MuonTrap's OS-level kill-safety** in escript mode. Documented in code. MuonTrap path works in mix/release contexts.
- **Some cheap models don't populate OpenRouter's `cost` field** — tokens are always tracked, cost shows $0 for those providers. Premium providers (OpenAI, Anthropic, Google) report cost correctly.

<details>
<summary>Changes (23 files, +1051/-225)</summary>

**New:**
- `lib/thinktank/models.ex` — tiered model catalog
- `lefthook.yml` — post-merge escript rebuild

**Modified (source):**
- `lib/thinktank/cli.ex` — `--tier` flag, remove `@default_models`, usage propagation
- `lib/thinktank/openrouter.ex` — extract usage/cost from responses
- `lib/thinktank/output.ex` — per-perspective usage, cost totals in manifest
- `lib/thinktank/dispatch/deep.ex` — stdin fix, exec, System.cmd fallback
- `lib/thinktank/dispatch/quick.ex` — 4-tuple results with usage
- `lib/thinktank/router.ex` — tier-based model selection, return usage
- `lib/thinktank/synthesis.ex` — tier-based model, return usage

**CI/config:**
- `.github/workflows/elixir-ci.yml` — dialyzer, hex.audit, PLT cache
- `.credo.exs` — strict: true
- `.pre-commit-config.yaml` — remove redundant --strict flag
- `mix.exs` — coverage threshold
- `scripts/validate-elixir-models.sh` — new provider prefixes

</details>

<details>
<summary>Test Coverage</summary>

142 tests across 11 test files. Key additions:
- Models tier invariant tests (no snapshot assertions — survive model rotation)
- OpenRouter usage extraction + zero-fallback
- Output cost tracking, totals computation, nil handling
- CLI `--tier` parsing including invalid tier error
- Deep mode shell escaping (backticks, $, newlines, empty, single quotes)
- Router/synthesis tier-based model selection

</details>

<details>
<summary>Manual QA</summary>

```bash
./thinktank --version                    # 6.1.0
./thinktank --help                       # shows --tier flag
./thinktank "test" --quick --tier cheap --dry-run --json  # tier in output
./thinktank "test" --quick --tier cheap --perspectives 2  # cheap models
./thinktank "test" --deep --perspectives 1 --roles "tester"  # deep mode works
lefthook run post-merge                   # rebuilds escript
```

</details>

<details>
<summary>Merge Confidence</summary>

**High.** All quality gates pass (142 tests, dialyzer, credo, format). Both quick and deep modes verified end-to-end with real API calls across cheap and standard tiers. Review bot findings (orphaned process, PLT cache path) addressed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic reinstall and escript rebuild on post-merge.

* **Improvements**
  * Safer, more reliable agent execution with a shell-based fallback.
  * Tier-aware model selection (cheap/standard/premium) across CLI, routing, and synthesis.
  * Usage and cost tracking surfaced in outputs and run manifests.

* **CI**
  * Added caching, dialyzer, and hex audit; adjusted lint invocation.

* **Chores**
  * Ignore entries added for agent cache and logs.

* **Tests**
  * Expanded coverage for invocation/escaping, tiers, usage propagation, and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->