### PR TITLE
feat(ci): enforce 80% coverage threshold with ExCoveralls

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Hex audit
         run: mix hex.audit
 
-      - name: Run tests
-        run: mix test
+      - name: Run tests with coverage
+        run: mix coveralls
 
       - name: Build escript
         run: mix escript.build

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,4 @@
+{
+  "minimum_coverage": 80,
+  "skip_files": []
+}

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -54,33 +54,47 @@ defmodule Thinktank.CLI do
   def exit_codes, do: @exit_codes
 
   @doc """
-  Escript entry point.
+  Escript entry point. Parses args, executes, and halts.
   """
   @spec main([String.t()]) :: no_return()
   def main(args) do
-    result =
-      case parse_args(args) do
+    exit_code =
+      args
+      |> parse_args()
+      |> then(fn
         {:needs_stdin, parsed} -> try_stdin(parsed)
         other -> other
-      end
+      end)
+      |> execute()
 
-    case result do
-      {:help, _} ->
-        print_usage()
-        System.halt(@exit_codes.success)
+    System.halt(exit_code)
+  end
 
-      {:version, _} ->
-        IO.puts("thinktank #{version()}")
-        System.halt(@exit_codes.success)
+  @doc """
+  Execute a parsed command. Returns an exit code without halting.
 
-      {:error, message} ->
-        IO.puts(:stderr, "Error: #{message}")
-        IO.puts(:stderr, "Run 'thinktank --help' for usage.")
-        System.halt(@exit_codes.input_error)
+  Testable core — `main/1` is the only function that calls `System.halt/1`.
+  """
+  @spec execute({:ok, map()} | {:error, String.t()} | {:help, keyword()} | {:version, keyword()}) ::
+          non_neg_integer()
+  def execute({:help, _}) do
+    IO.puts(usage_text())
+    @exit_codes.success
+  end
 
-      {:ok, opts} ->
-        run(opts)
-    end
+  def execute({:version, _}) do
+    IO.puts("thinktank #{version()}")
+    @exit_codes.success
+  end
+
+  def execute({:error, message}) do
+    IO.puts(:stderr, "Error: #{message}")
+    IO.puts(:stderr, "Run 'thinktank --help' for usage.")
+    @exit_codes.input_error
+  end
+
+  def execute({:ok, opts}) do
+    run(opts)
   end
 
   @doc false
@@ -162,7 +176,6 @@ defmodule Thinktank.CLI do
     }
   end
 
-  @spec run(map()) :: no_return()
   defp run(%{dry_run: true} = opts) do
     if opts.json do
       IO.puts(dry_run_output(opts))
@@ -175,7 +188,7 @@ defmodule Thinktank.CLI do
       end
     end
 
-    System.halt(@exit_codes.success)
+    @exit_codes.success
   end
 
   defp run(%{mode: :quick} = opts) do
@@ -191,12 +204,11 @@ defmodule Thinktank.CLI do
     end)
   end
 
-  @spec dispatch_and_finalize(map(), function()) :: no_return()
   defp dispatch_and_finalize(opts, dispatch_fn) do
     case resolve_perspectives(opts) do
       {:error, reason} ->
         IO.puts(:stderr, "Error: #{reason}")
-        System.halt(@exit_codes.input_error)
+        @exit_codes.input_error
 
       {:ok, perspectives, router_usage} ->
         output_dir = opts.output || generate_output_dir()
@@ -213,7 +225,7 @@ defmodule Thinktank.CLI do
         maybe_synthesize(opts, synthesis_successes, output_dir)
         Output.complete_run(output_dir)
         emit_result(opts, output_dir)
-        exit_on_results(successes)
+        exit_code_for_results(successes)
     end
   end
 
@@ -238,13 +250,12 @@ defmodule Thinktank.CLI do
     end
   end
 
-  @spec exit_on_results([{String.t(), String.t(), map() | nil}]) :: no_return()
-  defp exit_on_results([]) do
+  defp exit_code_for_results([]) do
     IO.puts(:stderr, "Error: all perspective dispatches failed")
-    System.halt(@exit_codes.generic_error)
+    @exit_codes.generic_error
   end
 
-  defp exit_on_results(_successes), do: System.halt(@exit_codes.success)
+  defp exit_code_for_results(_successes), do: @exit_codes.success
 
   defp resolve_perspectives(opts) do
     models = if opts.models != [], do: opts.models, else: Models.models_for_tier(opts.tier)
@@ -260,14 +271,22 @@ defmodule Thinktank.CLI do
     end
   end
 
-  defp generate_output_dir do
+  @doc """
+  Generate a unique timestamped output directory path.
+  """
+  @spec generate_output_dir() :: String.t()
+  def generate_output_dir do
     timestamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d-%H%M%S")
     suffix = :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
     Path.join(System.tmp_dir!(), "thinktank-#{timestamp}-#{suffix}")
   end
 
-  defp print_usage do
-    IO.puts("""
+  @doc """
+  Returns the usage help text.
+  """
+  @spec usage_text() :: String.t()
+  def usage_text do
+    """
     thinktank — multi-perspective AI research tool
 
     USAGE
@@ -310,7 +329,7 @@ defmodule Thinktank.CLI do
       thinktank "suggest project names" --quick --tier cheap
       thinktank "audit for security issues" --tier premium --perspectives 5
       echo "compare approaches" | thinktank --quick
-    """)
+    """
   end
 
   defp parse_tier(nil), do: {:ok, :standard}
@@ -326,10 +345,14 @@ defmodule Thinktank.CLI do
 
   defp version, do: Application.spec(:thinktank, :vsn) |> to_string()
 
-  # Resolve agent config directory for deep mode Pi agents.
-  # Checks THINKTANK_AGENT_CONFIG env var first, then CWD/agent_config.
-  # Returns nil when no config directory is found (Deep runs without it).
-  defp agent_config_dir do
+  @doc """
+  Resolve agent config directory for deep mode Pi agents.
+
+  Checks `THINKTANK_AGENT_CONFIG` env var first, then `CWD/agent_config`.
+  Returns `nil` when no config directory is found.
+  """
+  @spec agent_config_dir() :: String.t() | nil
+  def agent_config_dir do
     case System.get_env("THINKTANK_AGENT_CONFIG") do
       nil ->
         dir = Path.join(File.cwd!(), "agent_config")

--- a/lib/thinktank/dispatch/deep.ex
+++ b/lib/thinktank/dispatch/deep.ex
@@ -106,22 +106,25 @@ defmodule Thinktank.Dispatch.Deep do
     end
   end
 
-  # MuonTrap's priv binary is unavailable in escripts — fall back to System.cmd.
-  defp default_runner do
+  @doc false
+  def default_runner do
     if muontrap_available?(), do: &MuonTrap.cmd/3, else: &system_cmd/3
   end
 
-  defp muontrap_available? do
+  @doc false
+  def muontrap_available? do
     path = MuonTrap.muontrap_path()
     File.exists?(path)
   rescue
     _ -> false
   end
 
-  # Escript fallback: System.cmd does NOT provide OS-level kill-safety.
-  # On timeout, the Elixir task is killed but the OS process (pi) may
-  # survive. MuonTrap path (mix/release) provides true kill-safety.
-  defp system_cmd(cmd, args, opts) do
+  @doc """
+  Escript fallback runner. System.cmd does NOT provide OS-level kill-safety.
+  On timeout, the Elixir task is killed but the OS process may survive.
+  MuonTrap path (mix/release) provides true kill-safety.
+  """
+  def system_cmd(cmd, args, opts) do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     env = Keyword.get(opts, :env, [])
 

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -1,6 +1,8 @@
 defmodule Thinktank.CLITest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   alias Thinktank.CLI
 
   describe "parse_args/1" do
@@ -188,6 +190,163 @@ defmodule Thinktank.CLITest do
 
       assert decoded["models"] == ["model-a", "model-b"]
       assert decoded["roles"] == ["auditor", "reviewer"]
+    end
+  end
+
+  describe "execute/1 — help" do
+    test "prints usage text and returns success exit code" do
+      output =
+        capture_io(fn ->
+          assert CLI.execute({:help, []}) == 0
+        end)
+
+      assert output =~ "thinktank"
+      assert output =~ "USAGE"
+      assert output =~ "--help"
+    end
+  end
+
+  describe "execute/1 — version" do
+    test "prints version string and returns success exit code" do
+      output =
+        capture_io(fn ->
+          assert CLI.execute({:version, []}) == 0
+        end)
+
+      assert output =~ "thinktank "
+    end
+  end
+
+  describe "execute/1 — error" do
+    test "prints error to stderr and returns input_error exit code" do
+      stderr =
+        capture_io(:stderr, fn ->
+          assert CLI.execute({:error, "bad input"}) == 7
+        end)
+
+      assert stderr =~ "Error: bad input"
+      assert stderr =~ "Run 'thinktank --help' for usage."
+    end
+  end
+
+  describe "execute/1 — dry run" do
+    test "text mode prints plan summary and returns success" do
+      {:ok, opts} = CLI.parse_args(["test question", "--dry-run"])
+
+      output =
+        capture_io(fn ->
+          assert CLI.execute({:ok, opts}) == 0
+        end)
+
+      assert output =~ "Dry run: would dispatch 4 perspectives in deep mode"
+      assert output =~ "Instruction: test question"
+    end
+
+    test "text mode includes paths when provided" do
+      {:ok, opts} = CLI.parse_args(["test", "--dry-run", "--paths", "./src"])
+
+      output =
+        capture_io(fn ->
+          assert CLI.execute({:ok, opts}) == 0
+        end)
+
+      assert output =~ "Paths:"
+      assert output =~ "src"
+    end
+
+    test "json mode outputs valid JSON and returns success" do
+      {:ok, opts} = CLI.parse_args(["test question", "--dry-run", "--json"])
+
+      output =
+        capture_io(fn ->
+          assert CLI.execute({:ok, opts}) == 0
+        end)
+
+      assert {:ok, decoded} = Jason.decode(String.trim(output))
+      assert decoded["mode"] == "dry_run"
+      assert decoded["instruction"] == "test question"
+    end
+
+    test "quick mode flag is reflected in dry run" do
+      {:ok, opts} = CLI.parse_args(["test", "--dry-run", "--quick"])
+
+      output =
+        capture_io(fn ->
+          assert CLI.execute({:ok, opts}) == 0
+        end)
+
+      assert output =~ "quick mode"
+    end
+  end
+
+  describe "usage_text/0" do
+    test "includes all sections" do
+      text = CLI.usage_text()
+      assert text =~ "USAGE"
+      assert text =~ "ARGUMENTS"
+      assert text =~ "OPTIONS"
+      assert text =~ "EXIT CODES"
+      assert text =~ "EXAMPLES"
+    end
+
+    test "documents all flags" do
+      text = CLI.usage_text()
+      assert text =~ "--paths"
+      assert text =~ "--quick"
+      assert text =~ "--deep"
+      assert text =~ "--tier"
+      assert text =~ "--json"
+      assert text =~ "--output"
+      assert text =~ "--models"
+      assert text =~ "--roles"
+      assert text =~ "--perspectives"
+      assert text =~ "--dry-run"
+      assert text =~ "--no-synthesis"
+      assert text =~ "--help"
+      assert text =~ "--version"
+    end
+  end
+
+  describe "generate_output_dir/0" do
+    test "returns path under system tmp dir" do
+      dir = CLI.generate_output_dir()
+      assert String.starts_with?(dir, System.tmp_dir!())
+    end
+
+    test "includes thinktank prefix with timestamp and random suffix" do
+      dir = CLI.generate_output_dir()
+      assert Path.basename(dir) =~ ~r/^thinktank-\d{8}-\d{6}-[0-9a-f]{8}$/
+    end
+
+    test "generates unique paths" do
+      dirs = for _ <- 1..5, do: CLI.generate_output_dir()
+      assert length(Enum.uniq(dirs)) == 5
+    end
+  end
+
+  describe "agent_config_dir/0" do
+    test "returns env var path when THINKTANK_AGENT_CONFIG is set" do
+      System.put_env("THINKTANK_AGENT_CONFIG", "/custom/config")
+      assert CLI.agent_config_dir() == "/custom/config"
+    after
+      System.delete_env("THINKTANK_AGENT_CONFIG")
+    end
+
+    test "returns CWD/agent_config when directory exists and no env var" do
+      System.delete_env("THINKTANK_AGENT_CONFIG")
+      dir = CLI.agent_config_dir()
+      assert dir == Path.join(File.cwd!(), "agent_config")
+    end
+
+    test "returns nil when no env var and no agent_config dir exists" do
+      System.delete_env("THINKTANK_AGENT_CONFIG")
+      # Run in a tmp dir that has no agent_config subdirectory
+      tmp = System.tmp_dir!()
+      cwd = File.cwd!()
+      File.cd!(tmp)
+      result = CLI.agent_config_dir()
+      File.cd!(cwd)
+      assert result == nil
     end
   end
 end

--- a/test/thinktank/dispatch/deep_test.exs
+++ b/test/thinktank/dispatch/deep_test.exs
@@ -372,6 +372,43 @@ defmodule Thinktank.Dispatch.DeepTest do
     end
   end
 
+  describe "muontrap_available?/0" do
+    test "returns a boolean" do
+      result = Deep.muontrap_available?()
+      assert is_boolean(result)
+    end
+  end
+
+  describe "default_runner/0" do
+    test "returns a function" do
+      runner = Deep.default_runner()
+      assert is_function(runner, 3)
+    end
+  end
+
+  describe "system_cmd/3 — escript fallback runner" do
+    test "returns {output, 0} for successful commands" do
+      {output, exit_code} = Deep.system_cmd("echo", ["hello"], [])
+      assert exit_code == 0
+      assert String.trim(output) == "hello"
+    end
+
+    test "returns non-zero exit code for failed commands" do
+      {_output, exit_code} = Deep.system_cmd("sh", ["-c", "exit 42"], [])
+      assert exit_code == 42
+    end
+
+    test "forwards env to subprocess" do
+      {output, 0} = Deep.system_cmd("sh", ["-c", "echo $TEST_VAR"], env: [{"TEST_VAR", "works"}])
+      assert String.trim(output) == "works"
+    end
+
+    test "returns timeout tuple when command exceeds timeout" do
+      {_output, status} = Deep.system_cmd("sleep", ["10"], timeout: 100)
+      assert status == :timeout
+    end
+  end
+
   # Flush all messages with a given tag, collecting the payloads
   defp flush_tagged(tag), do: flush_tagged(tag, [])
 


### PR DESCRIPTION
## Why This Matters

CI had no coverage enforcement — `ExCoveralls` was configured in `mix.exs` but never invoked. An agent could merge untested code without CI noticing. Coverage was 70.5% with key CLI orchestration paths completely untested because they called `System.halt` directly.

Closes #262

## Trade-offs / Risks

- Refactored `cli.ex` to separate `System.halt` from logic. This is a structural change to a core module, but the `main/1` contract is unchanged.
- Made `Deep.system_cmd/3` and `Deep.muontrap_available?/0` public to enable testing. These are implementation details but useful for introspection.
- 80% threshold is firm — matches the Go-era discipline. Current coverage is 80.5%, giving ~2 lines of headroom.

## Intent Reference

> Elixir CI enforces a minimum coverage threshold, matching the Go side's discipline.

Source: #262

## Changes

- **`lib/thinktank/cli.ex`**: Extract `execute/1` (returns exit code, no halt), `usage_text/0`, make `generate_output_dir/0` and `agent_config_dir/0` public
- **`lib/thinktank/dispatch/deep.ex`**: Make `system_cmd/3`, `muontrap_available?/0`, `default_runner/0` public
- **`test/thinktank/cli_test.exs`**: 15 new tests for execute paths, usage text, output dir, agent config
- **`test/thinktank/dispatch/deep_test.exs`**: 6 new tests for fallback runner, muontrap detection
- **`.github/workflows/elixir-ci.yml`**: Replace `mix test` with `mix coveralls`
- **`coveralls.json`**: New file, sets `minimum_coverage: 80`

## Alternatives Considered

- **Just set threshold without adding tests**: Would require lowering threshold to 70%, violating the issue's explicit boundary ("Do NOT lower threshold").
- **Mock external deps to test dispatch paths**: Over-engineering — dry-run + fallback runner tests were sufficient to cross 80%.
- **Use `mix test --cover` instead of ExCoveralls**: ExCoveralls is already a dep, provides threshold enforcement, and produces richer reports.

## Acceptance Criteria

- [x] `mix coveralls` reports coverage for all Elixir modules (80.5% total)
- [x] CI fails if coverage drops below threshold (80%, enforced via `coveralls.json`)
- [x] New modules without tests are flagged (ExCoveralls reports per-module coverage)

## Manual QA

```bash
# Run coverage locally
MIX_ENV=test mix coveralls
# Expected: 80.5%, exit 0

# Verify threshold enforcement (temporarily set higher)
# In coveralls.json: "minimum_coverage": 95
MIX_ENV=test mix coveralls
# Expected: FAILED message, exit 1
```

## What Changed

```mermaid
flowchart LR
    A[mix test] --> B[Tests pass/fail]
    B --> C[No coverage check]
```

```mermaid
flowchart LR
    A[mix coveralls] --> B[Tests pass/fail]
    B --> C{Coverage >= 80%?}
    C -->|Yes| D[CI green]
    C -->|No| E[CI red]
```

```mermaid
graph TD
    A[CLI.main/1] -->|only halt point| B[System.halt]
    A --> C[CLI.execute/1]
    C -->|testable| D[help/version/error/dry-run]
    C -->|testable| E[dispatch pipeline]
```

The refactoring separates the halt-or-return decision from the logic, making the entire CLI pipeline testable in-process.

## Test Coverage

- `test/thinktank/cli_test.exs`: 45 tests (15 new) — execute paths, usage text, output dir, agent config
- `test/thinktank/dispatch/deep_test.exs`: 24 tests (6 new) — system_cmd, muontrap, default_runner
- Total: 165 tests, 0 failures, 80.5% coverage

## Merge Confidence

**High** — All quality gates pass (format, compile, credo, dialyzer, coverage). The refactoring is behavior-preserving: `main/1` still parses→executes→halts, just with the halt isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing & Quality**
  * CI workflow now uses coverage reporting with an enforced 80% minimum code coverage threshold.
  * Expanded test suite coverage across the CLI and dispatch modules for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->