### PR TITLE
[codex] Add planner-driven review benches and replay evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Thin Pi bench launcher for research and code review.
 ThinkTank defines named Pi agents, groups them into benches, launches them in
 parallel against the current workspace, and writes raw artifacts. It does not
 precompute semantic context, route through a workflow DSL, or parse agent prose
-with regexes.
+with regexes. Review benches can optionally run a planning agent first to pick
+the reviewer subset and write a lightweight context pack.
 
 Built with Elixir/OTP.
 
@@ -37,6 +38,7 @@ export OPENROUTER_API_KEY="your-key"
 thinktank run <bench> --input "..." [options]
 thinktank research "..." [options]
 thinktank review [options]
+thinktank review eval <contract-or-dir> [--bench <bench>]
 thinktank benches list|show|validate
 ```
 
@@ -59,6 +61,7 @@ thinktank benches list|show|validate
 | `--head REF` | Review head ref |
 | `--repo REPO` | Review repo owner/name |
 | `--pr N` | Review pull request number |
+| `--bench BENCH` | Bench override for `review eval` |
 
 ### Examples
 
@@ -68,6 +71,9 @@ thinktank research "what is wrong with this architecture?" --paths ./lib
 
 # Fixed review bench
 thinktank review --base origin/main --head HEAD
+
+# Replay frozen review workloads through a different bench
+thinktank review eval ./tmp/review-run --bench review/constellation
 
 # Explicit bench invocation with a subset of agents
 thinktank run review/cerberus --input "Review this branch" --agents trace,guard
@@ -89,6 +95,7 @@ Built-in benches:
 
 - `research/default`
 - `review/cerberus`
+- `review/constellation`
 
 Config shape:
 
@@ -113,6 +120,7 @@ benches:
     kind: review
     description: Fixed review bench
     agents: [trace, guard, atlas, proof]
+    planner: marshal
     synthesizer: review-synth
     concurrency: 4
     default_task: Review the current change and report only real issues with evidence.
@@ -138,6 +146,7 @@ benches:
     kind: review
     description: Security-focused review bench
     agents: [guard]
+    planner: marshal
     default_task: Review the current change for real security issues.
 ```
 
@@ -152,6 +161,9 @@ Each run writes:
 - `summary.md` — synthesizer output when enabled
 - `synthesis.md` for research benches
 - `review.md` for review benches
+- `review/context.json` and `review/context.md` for review benches
+- `review/plan.json` and `review/plan.md` for review benches
+- `review/planner.md` when a planner agent runs
 - `manifest.json` — run metadata and artifact index
 
 ThinkTank records raw outputs and run metadata. It does not attempt to recover
@@ -159,12 +171,25 @@ structure from agent prose after the fact.
 
 ## Review Notes
 
-- `review/cerberus` does not materialize a diff bundle. Reviewers are expected
+- Review benches do not materialize a patch bundle. Reviewers are still expected
   to inspect the repo and git state themselves.
+- ThinkTank may write a light review context pack and review plan before
+  launching reviewers. These are orientation artifacts, not substitutes for
+  repository exploration.
+- `review/cerberus` uses a small default roster with `marshal` as planner.
+- `review/constellation` exposes the full cross-model reviewer bench for wider
+  coverage and experimentation.
 - `--base`, `--head`, `--repo`, and `--pr` are orientation hints for the
   reviewers and synthesizer.
 - Repository-local `agent_config/` is only loaded when
   `THINKTANK_TRUST_REPO_AGENT_CONFIG=1` is set.
+
+## Replay Eval
+
+`thinktank review eval` is intentionally narrow. It replays one or more saved
+`contract.json` review workloads through a bench and writes fresh artifacts so
+you can compare benches on the same frozen inputs. It does not impose an
+automatic scoring framework.
 
 ## Development
 

--- a/lib/thinktank/bench_spec.ex
+++ b/lib/thinktank/bench_spec.ex
@@ -9,6 +9,7 @@ defmodule Thinktank.BenchSpec do
     :description,
     kind: :default,
     agents: [],
+    planner: nil,
     synthesizer: nil,
     concurrency: nil,
     default_task: nil
@@ -21,6 +22,7 @@ defmodule Thinktank.BenchSpec do
           description: String.t(),
           kind: kind(),
           agents: [String.t()],
+          planner: String.t() | nil,
           synthesizer: String.t() | nil,
           concurrency: pos_integer() | nil,
           default_task: String.t() | nil
@@ -31,6 +33,7 @@ defmodule Thinktank.BenchSpec do
     with {:ok, description} <- require_string(raw, "description"),
          {:ok, kind} <- parse_kind(raw["kind"]),
          {:ok, agents} <- require_agent_names(raw["agents"]),
+         {:ok, planner} <- optional_string(raw["planner"]),
          {:ok, synthesizer} <- optional_string(raw["synthesizer"]),
          {:ok, concurrency} <- parse_concurrency(raw["concurrency"]),
          {:ok, default_task} <- optional_string(raw["default_task"]) do
@@ -40,6 +43,7 @@ defmodule Thinktank.BenchSpec do
          description: description,
          kind: kind,
          agents: agents,
+         planner: planner,
          synthesizer: synthesizer,
          concurrency: concurrency,
          default_task: default_task

--- a/lib/thinktank/builtin.ex
+++ b/lib/thinktank/builtin.ex
@@ -49,22 +49,34 @@ defmodule Thinktank.Builtin do
             @research_tools,
             thinking_level: "low"
           ),
+        "marshal" =>
+          agent(
+            "marshal",
+            "google/gemini-3.1-pro-preview",
+            marshal_prompt(),
+            review_plan_task_prompt(),
+            @review_tools,
+            thinking_level: "high",
+            metadata: %{"review_role" => "planner"}
+          ),
         "trace" =>
           agent(
             "trace",
-            "x-ai/grok-4.1-fast",
+            "x-ai/grok-4.20-beta",
             trace_prompt(),
             review_task_prompt(),
-            @review_tools
+            @review_tools,
+            metadata: %{"review_role" => "correctness"}
           ),
         "guard" =>
           agent(
             "guard",
-            "google/gemini-3-flash-preview",
+            "x-ai/grok-4.20-multi-agent-beta",
             guard_prompt(),
             review_task_prompt(),
             @review_tools,
-            thinking_level: "low"
+            thinking_level: "low",
+            metadata: %{"review_role" => "security"}
           ),
         "atlas" =>
           agent(
@@ -72,22 +84,79 @@ defmodule Thinktank.Builtin do
             "anthropic/claude-sonnet-4.6",
             atlas_prompt(),
             review_task_prompt(),
-            @review_tools
+            @review_tools,
+            metadata: %{"review_role" => "architecture"}
           ),
         "proof" =>
           agent(
             "proof",
-            "mistralai/mistral-large-2512",
+            "openai/gpt-5.4-mini",
             proof_prompt(),
             review_task_prompt(),
-            @review_tools
+            @review_tools,
+            metadata: %{"review_role" => "tests"}
+          ),
+        "vector" =>
+          agent(
+            "vector",
+            "z-ai/glm-5-turbo",
+            vector_prompt(),
+            review_task_prompt(),
+            @review_tools,
+            metadata: %{"review_role" => "interfaces"}
+          ),
+        "pulse" =>
+          agent(
+            "pulse",
+            "minimax/minimax-m2.7",
+            pulse_prompt(),
+            review_task_prompt(),
+            @review_tools,
+            metadata: %{"review_role" => "runtime-risk"}
+          ),
+        "scout" =>
+          agent(
+            "scout",
+            "google/gemini-3-flash-preview",
+            scout_prompt(),
+            review_task_prompt(),
+            @review_tools,
+            thinking_level: "low",
+            metadata: %{"review_role" => "integration"}
+          ),
+        "forge" =>
+          agent(
+            "forge",
+            "inception/mercury-2",
+            forge_prompt(),
+            review_task_prompt(),
+            @review_tools,
+            metadata: %{"review_role" => "implementation"}
+          ),
+        "orbit" =>
+          agent(
+            "orbit",
+            "moonshotai/kimi-k2.5",
+            orbit_prompt(),
+            review_task_prompt(),
+            @review_tools,
+            metadata: %{"review_role" => "compatibility"}
+          ),
+        "sentry" =>
+          agent(
+            "sentry",
+            "xiaomi/mimo-v2-pro",
+            sentry_prompt(),
+            review_task_prompt(),
+            @review_tools,
+            metadata: %{"review_role" => "operability"}
           ),
         "research-synth" =>
           agent(
             "research-synth",
             "openai/gpt-5.4",
             research_synth_prompt(),
-            synthesis_task_prompt(),
+            research_synthesis_task_prompt(),
             @summary_tools
           ),
         "review-synth" =>
@@ -95,7 +164,7 @@ defmodule Thinktank.Builtin do
             "review-synth",
             "openai/gpt-5.4",
             review_synth_prompt(),
-            synthesis_task_prompt(),
+            review_synthesis_task_prompt(),
             @summary_tools
           )
       },
@@ -111,10 +180,32 @@ defmodule Thinktank.Builtin do
         "review/cerberus" => %{
           "kind" => "review",
           "description" =>
-            "Launch a fixed review bench of Pi agents against the current repository context.",
-          "agents" => ["trace", "guard", "atlas", "proof"],
+            "Launch the default review bench: a planner plus a focused team of specialist reviewers.",
+          "agents" => ["trace", "guard", "atlas", "proof", "scout"],
+          "planner" => "marshal",
           "synthesizer" => "review-synth",
-          "concurrency" => 4,
+          "concurrency" => 5,
+          "default_task" => "Review the current change and report only real issues with evidence."
+        },
+        "review/constellation" => %{
+          "kind" => "review",
+          "description" =>
+            "Launch the expanded review roster across model families with a planner and synthesizer.",
+          "agents" => [
+            "trace",
+            "guard",
+            "atlas",
+            "proof",
+            "vector",
+            "pulse",
+            "scout",
+            "forge",
+            "orbit",
+            "sentry"
+          ],
+          "planner" => "marshal",
+          "synthesizer" => "review-synth",
+          "concurrency" => 8,
           "default_task" => "Review the current change and report only real issues with evidence."
         }
       }
@@ -122,6 +213,10 @@ defmodule Thinktank.Builtin do
   end
 
   defp agent(name, model, system_prompt, task_prompt, tools, opts \\ []) do
+    metadata =
+      %{"agent" => name}
+      |> Map.merge(Keyword.get(opts, :metadata, %{}))
+
     %{
       "provider" => "openrouter",
       "model" => model,
@@ -131,7 +226,7 @@ defmodule Thinktank.Builtin do
       "thinking_level" => Keyword.get(opts, :thinking_level, "medium"),
       "retries" => Keyword.get(opts, :retries, 0),
       "timeout_ms" => Keyword.get(opts, :timeout_ms, :timer.minutes(10)),
-      "metadata" => %{"agent" => name}
+      "metadata" => metadata
     }
   end
 
@@ -161,6 +256,16 @@ defmodule Thinktank.Builtin do
     Focus paths:
     {{paths_hint}}
 
+    Review role: {{review_role}}
+    Assigned brief:
+    {{review_brief}}
+
+    Review context:
+    {{review_context}}
+
+    Bench plan:
+    {{review_plan}}
+
     You are doing code review. Use bash, git, and file tools to inspect the current repository yourself.
     Start with git status and git diff. If base/head are provided, compare them. If repo/pr are provided,
     use them as orientation, not as a substitute for local inspection. Report only issues you can ground in
@@ -168,7 +273,54 @@ defmodule Thinktank.Builtin do
     """
   end
 
-  defp synthesis_task_prompt do
+  defp review_plan_task_prompt do
+    """
+    {{input_text}}
+
+    Workspace root: {{workspace_root}}
+    Repo: {{repo}}
+    PR: {{pr}}
+    Base ref: {{base}}
+    Head ref: {{head}}
+    Focus paths:
+    {{paths_hint}}
+
+    Review context:
+    {{review_context}}
+
+    Available reviewers:
+    {{review_roster}}
+
+    Return JSON only with this shape:
+    {
+      "summary": "one short paragraph",
+      "selected_agents": [
+        {"name": "trace", "brief": "what this reviewer should focus on"}
+      ],
+      "synthesis_brief": "what the synthesizer should prioritize",
+      "warnings": ["optional planner caveat"]
+    }
+
+    Pick only reviewers that materially add signal for this change. Avoid selecting everyone unless the
+    change is genuinely broad. Do not report findings here. This step is only planning and tasking.
+    """
+  end
+
+  defp research_synthesis_task_prompt do
+    """
+    Original task:
+    {{input_text}}
+
+    Workspace root: {{workspace_root}}
+    Focus paths:
+    {{paths_hint}}
+
+    Agent outputs:
+    {{agent_outputs}}
+    """
+  end
+
+  defp review_synthesis_task_prompt do
     """
     Original task:
     {{input_text}}
@@ -180,6 +332,12 @@ defmodule Thinktank.Builtin do
     Head ref: {{head}}
     Focus paths:
     {{paths_hint}}
+
+    Review context:
+    {{review_context}}
+
+    Review plan:
+    {{review_plan}}
 
     Agent outputs:
     {{agent_outputs}}
@@ -214,6 +372,15 @@ defmodule Thinktank.Builtin do
     """
   end
 
+  defp marshal_prompt do
+    """
+    You are marshal, the review planner. Build a concise plan for this change:
+    likely risk zones, where reviewers should focus, and what evidence would confirm risk.
+    Do not claim defects unless you can ground them directly in inspected code. Prefer a small, relevant
+    team over exhaustive fan-out.
+    """
+  end
+
   defp trace_prompt do
     """
     You are trace, a correctness reviewer. Hunt for behavioral regressions, broken assumptions,
@@ -239,6 +406,48 @@ defmodule Thinktank.Builtin do
     """
     You are proof, a testing reviewer. Focus on concrete regression risk, brittle tests,
     and behavior that remains unverified.
+    """
+  end
+
+  defp vector_prompt do
+    """
+    You are vector, an API and interface reviewer. Focus on boundary contracts, caller impact,
+    and mismatches between module intent and exposed behavior.
+    """
+  end
+
+  defp pulse_prompt do
+    """
+    You are pulse, a runtime-risk reviewer. Focus on latency spikes, concurrency hazards,
+    resource leaks, and any behavior that can fail under production load.
+    """
+  end
+
+  defp scout_prompt do
+    """
+    You are scout, an integration reviewer. Focus on how this change interacts with adjacent
+    modules, external services, and deployment expectations.
+    """
+  end
+
+  defp forge_prompt do
+    """
+    You are forge, an implementation reviewer. Focus on hidden complexity, brittle control flow,
+    and whether the change is harder to operate than necessary.
+    """
+  end
+
+  defp orbit_prompt do
+    """
+    You are orbit, a compatibility reviewer. Focus on upgrade paths, backward compatibility,
+    and behavior differences across expected execution environments.
+    """
+  end
+
+  defp sentry_prompt do
+    """
+    You are sentry, an operability reviewer. Focus on failure visibility, logging and diagnostics,
+    and whether this change is supportable when incidents happen.
     """
   end
 

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -4,6 +4,7 @@ defmodule Thinktank.CLI do
   """
 
   alias Thinktank.{BenchSpec, Config, Engine}
+  alias Thinktank.Review.Eval
 
   @exit_codes %{
     success: 0,
@@ -18,6 +19,7 @@ defmodule Thinktank.CLI do
       input: :string,
       paths: :keep,
       agents: :string,
+      bench: :string,
       json: :boolean,
       output: :string,
       dry_run: :boolean,
@@ -94,6 +96,7 @@ defmodule Thinktank.CLI do
           description: bench.description,
           kind: bench.kind,
           agents: bench.agents,
+          planner: bench.planner,
           synthesizer: bench.synthesizer,
           concurrency: bench.concurrency,
           default_task: bench.default_task
@@ -126,6 +129,26 @@ defmodule Thinktank.CLI do
       dry_run(command)
     else
       run_bench(command)
+    end
+  end
+
+  def execute({:ok, %{action: :review_eval} = command}) do
+    eval_opts =
+      [bench_id: command.bench_id, output: command.output]
+      |> maybe_put_opt(:trust_repo_config, command.trust_repo_config)
+
+    case Eval.run(command.target, eval_opts) do
+      {:ok, result} ->
+        emit_eval(command, result)
+
+        case result.status do
+          "complete" -> @exit_codes.success
+          _ -> @exit_codes.generic_error
+        end
+
+      {:error, reason} ->
+        IO.puts(:stderr, "Error: #{format_reason(reason)}")
+        @exit_codes.input_error
     end
   end
 
@@ -170,6 +193,7 @@ defmodule Thinktank.CLI do
       bench: resolved.bench.id,
       description: resolved.bench.description,
       agents: Enum.map(resolved.agents, & &1.name),
+      planner: resolved.planner && resolved.planner.name,
       synthesizer: resolved.synthesizer && resolved.synthesizer.name,
       input: command.input,
       output: resolved.output_dir,
@@ -183,6 +207,7 @@ defmodule Thinktank.CLI do
       Bench: #{payload.bench}
       Description: #{payload.description}
       Agents: #{Enum.join(payload.agents, ", ")}
+      Planner: #{payload.planner || "none"}
       Synthesizer: #{payload.synthesizer || "none"}
       Input: #{payload.input.input_text}
       Output: #{payload.output}
@@ -203,6 +228,21 @@ defmodule Thinktank.CLI do
       end
     end
   end
+
+  defp build_command(["review", "eval", target], parsed) do
+    {:ok,
+     %{
+       action: :review_eval,
+       target: Path.expand(target),
+       bench_id: parsed[:bench],
+       cwd: File.cwd!(),
+       json: parsed[:json] || false,
+       output: parsed[:output] && Path.expand(parsed[:output]),
+       trust_repo_config: parsed[:trust_repo_config]
+     }}
+  end
+
+  defp build_command(["review", "eval"], _parsed), do: {:error, "review eval requires a path"}
 
   defp build_command(["review" | remainder], parsed) do
     with {:ok, config, bench} <- resolve_bench("review/cerberus", parsed),
@@ -402,6 +442,19 @@ defmodule Thinktank.CLI do
     """)
   end
 
+  defp emit_eval(%{json: true}, payload), do: IO.puts(Jason.encode!(payload))
+
+  defp emit_eval(_command, payload) do
+    IO.puts("""
+    Review eval: #{payload.target}
+    Status: #{payload.status}
+    Output: #{payload.output_dir}
+
+    Cases:
+    #{render_eval_case_lines(payload.cases)}
+    """)
+  end
+
   defp render_agent_lines(agents) do
     Enum.map_join(agents, "\n", fn agent ->
       status = get_in(agent, ["metadata", "status"]) || "unknown"
@@ -412,6 +465,12 @@ defmodule Thinktank.CLI do
   defp render_artifact_lines(artifacts) do
     Enum.map_join(artifacts, "\n", fn artifact ->
       "- #{artifact["name"]}: #{artifact["file"]}"
+    end)
+  end
+
+  defp render_eval_case_lines(cases) do
+    Enum.map_join(cases, "\n", fn case_result ->
+      "- #{case_result.case_id}: #{case_result.status} (#{case_result.bench})"
     end)
   end
 
@@ -520,6 +579,7 @@ defmodule Thinktank.CLI do
       thinktank run <bench> --input "..." [options]
       thinktank research "..." [options]
       thinktank review [options]
+      thinktank review eval <contract-or-dir> [--bench <bench>]
       thinktank benches list|show|validate
 
     Options:
@@ -539,6 +599,7 @@ defmodule Thinktank.CLI do
     Examples:
       thinktank research "analyze this codebase" --paths ./lib
       thinktank review --base origin/main --head HEAD
+      thinktank review eval ./tmp/review-run --bench review/constellation
       thinktank run review/cerberus --input "Review this branch" --agents trace,guard
       thinktank benches show research/default
     """

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -541,7 +541,7 @@ defmodule Thinktank.CLI do
   defp maybe_put_opt(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp agent_config_dir(cwd) do
-    if trust_repo_agent_config?() do
+    if Config.trust_repo_agent_config?() do
       dir = Path.join(cwd, "agent_config")
       if File.dir?(dir), do: dir
     end
@@ -558,10 +558,6 @@ defmodule Thinktank.CLI do
     match?({:error, _}, :io.columns(:standard_io))
   rescue
     _ -> false
-  end
-
-  defp trust_repo_agent_config? do
-    System.get_env("THINKTANK_TRUST_REPO_AGENT_CONFIG") in ["1", "true", "TRUE", "yes", "YES"]
   end
 
   defp format_reason(:missing_input_text), do: "input text is required"

--- a/lib/thinktank/config.ex
+++ b/lib/thinktank/config.ex
@@ -60,6 +60,11 @@ defmodule Thinktank.Config do
     Path.join([home, ".config", "thinktank"])
   end
 
+  @spec trust_repo_agent_config?() :: boolean()
+  def trust_repo_agent_config? do
+    System.get_env("THINKTANK_TRUST_REPO_AGENT_CONFIG") in ["1", "true", "TRUE", "yes", "YES"]
+  end
+
   defp build(raw, sources) do
     with {:ok, providers} <- build_providers(Map.get(raw, "providers", %{})),
          {:ok, agents} <- build_agents(Map.get(raw, "agents", %{})),

--- a/lib/thinktank/config.ex
+++ b/lib/thinktank/config.ex
@@ -130,8 +130,10 @@ defmodule Thinktank.Config do
   defp bench_reference_error(bench, agents) do
     case validate_named_agents(bench.agents, agents) do
       :ok ->
-        case validate_optional_agent(bench.synthesizer, agents) do
-          :ok -> nil
+        with :ok <- validate_optional_agent(bench.planner, agents, "planner"),
+             :ok <- validate_optional_agent(bench.synthesizer, agents, "synthesizer") do
+          nil
+        else
           {:error, reason} -> reason
         end
 
@@ -150,9 +152,9 @@ defmodule Thinktank.Config do
   defp validate_named_agents(_, _agents),
     do: {:error, "bench agents must be a list of agent names"}
 
-  defp validate_optional_agent(nil, _agents), do: :ok
+  defp validate_optional_agent(nil, _agents, _field), do: :ok
 
-  defp validate_optional_agent(agent_name, agents) when is_binary(agent_name) do
+  defp validate_optional_agent(agent_name, agents, _field) when is_binary(agent_name) do
     if Map.has_key?(agents, agent_name) do
       :ok
     else
@@ -160,8 +162,8 @@ defmodule Thinktank.Config do
     end
   end
 
-  defp validate_optional_agent(_, _agents),
-    do: {:error, "bench synthesizer must be an agent name"}
+  defp validate_optional_agent(_, _agents, field),
+    do: {:error, "bench #{field} must be an agent name"}
 
   defp load_repo_yaml(_path, false), do: {:ok, %{}}
   defp load_repo_yaml(path, true), do: load_yaml_if_present(path)

--- a/lib/thinktank/engine.ex
+++ b/lib/thinktank/engine.ex
@@ -12,6 +12,7 @@ defmodule Thinktank.Engine do
   }
 
   alias Thinktank.Executor.Agentic
+  alias Thinktank.Review.{Context, Planner}
 
   @type run_result :: %{
           contract: RunContract.t(),
@@ -19,6 +20,7 @@ defmodule Thinktank.Engine do
           output_dir: String.t(),
           envelope: map(),
           agents: [AgentSpec.t()],
+          planner: AgentSpec.t() | nil,
           synthesizer: AgentSpec.t() | nil,
           results: [Agentic.result()],
           synthesis: Agentic.result() | nil
@@ -30,6 +32,7 @@ defmodule Thinktank.Engine do
           config: Config.t(),
           output_dir: String.t(),
           agents: [AgentSpec.t()],
+          planner: AgentSpec.t() | nil,
           synthesizer: AgentSpec.t() | nil
         }
 
@@ -46,6 +49,7 @@ defmodule Thinktank.Engine do
          {:ok, bench} <- Config.bench(config, bench_id),
          {:ok, input} <- normalize_input(bench, input),
          {:ok, agents} <- resolve_agents(bench, config, input),
+         {:ok, planner} <- resolve_planner(bench, config),
          {:ok, synthesizer} <- resolve_synthesizer(bench, config) do
       output_dir = Keyword.get(opts, :output, generate_output_dir(bench_id))
 
@@ -64,6 +68,7 @@ defmodule Thinktank.Engine do
          contract: contract,
          output_dir: output_dir,
          agents: agents,
+         planner: planner,
          synthesizer: synthesizer
        }}
     else
@@ -83,16 +88,20 @@ defmodule Thinktank.Engine do
          contract: contract,
          output_dir: output_dir,
          agents: agents,
+         planner: planner,
          synthesizer: synthesizer
        }} ->
         RunStore.init_run(output_dir, contract, bench)
         write_task_artifact(output_dir, contract.input)
 
-        context = %{"paths_hint" => render_paths_hint(contract.input)}
+        {planned_agents, context} =
+          prepare_execution(bench, agents, planner, contract, config, opts, output_dir)
+
+        RunStore.set_planned_agents(output_dir, Enum.map(planned_agents, & &1.name))
 
         results =
-          Agentic.run(agents, contract, context, config,
-            concurrency: bench.concurrency || length(agents),
+          Agentic.run(planned_agents, contract, context, config,
+            concurrency: bench.concurrency || length(planned_agents),
             agent_config_dir: opts[:agent_config_dir],
             runner: opts[:runner]
           )
@@ -119,7 +128,8 @@ defmodule Thinktank.Engine do
           bench: bench,
           output_dir: output_dir,
           envelope: RunStore.result_envelope(output_dir),
-          agents: agents,
+          agents: planned_agents,
+          planner: planner,
           synthesizer: synthesizer,
           results: results,
           synthesis: synthesis
@@ -275,6 +285,82 @@ defmodule Thinktank.Engine do
 
   defp normalize_input(_bench, _input), do: {:error, "input must be a map"}
 
+  defp prepare_execution(
+         %BenchSpec{kind: :review},
+         agents,
+         planner,
+         contract,
+         config,
+         opts,
+         output_dir
+       ) do
+    review_context = Context.capture(contract.workspace_root, contract.input)
+    planning = plan_review(agents, planner, contract, review_context, config, opts)
+    planned_agents = Planner.apply_plan(planning.plan, agents)
+    write_review_artifacts(output_dir, review_context, planning)
+
+    context = %{
+      "paths_hint" => render_paths_hint(contract.input),
+      "review_context" => Context.render(review_context),
+      "review_plan" => Planner.render(planning.plan)
+    }
+
+    {planned_agents, context}
+  end
+
+  defp prepare_execution(_bench, agents, _planner, contract, _config, _opts, _output_dir) do
+    {agents, %{"paths_hint" => render_paths_hint(contract.input)}}
+  end
+
+  defp plan_review(
+         agents,
+         planner,
+         contract,
+         review_context,
+         config,
+         opts
+       ) do
+    selected_agents = Map.get(contract.input, "agents", [])
+
+    cond do
+      selected_agents != [] ->
+        Planner.manual(agents)
+
+      true ->
+        Planner.create(planner, agents, contract, review_context, config,
+          agent_config_dir: opts[:agent_config_dir],
+          runner: opts[:runner]
+        )
+    end
+  end
+
+  defp write_review_artifacts(output_dir, review_context, %{plan: plan} = planning) do
+    RunStore.write_json_artifact(
+      output_dir,
+      "review-context",
+      "review/context.json",
+      review_context
+    )
+
+    RunStore.write_text_artifact(
+      output_dir,
+      "review-context-summary",
+      "review/context.md",
+      Context.render(review_context)
+    )
+
+    RunStore.write_json_artifact(output_dir, "review-plan", "review/plan.json", plan)
+
+    RunStore.write_text_artifact(
+      output_dir,
+      "review-plan-summary",
+      "review/plan.md",
+      Planner.render(plan)
+    )
+
+    maybe_write_planner_artifact(output_dir, planning)
+  end
+
   defp resolve_agents(%BenchSpec{agents: bench_agents}, %Config{agents: agents}, input) do
     names =
       case Map.get(input, "agents", []) do
@@ -284,6 +370,15 @@ defmodule Thinktank.Engine do
       end
 
     fetch_agents(agents, names)
+  end
+
+  defp resolve_planner(%BenchSpec{planner: nil}, _config), do: {:ok, nil}
+
+  defp resolve_planner(%BenchSpec{planner: name}, %Config{agents: agents}) do
+    case Map.fetch(agents, name) do
+      {:ok, agent} -> {:ok, agent}
+      :error -> {:error, "unknown planner: #{name}"}
+    end
   end
 
   defp resolve_synthesizer(%BenchSpec{synthesizer: nil}, _config), do: {:ok, nil}
@@ -335,6 +430,22 @@ defmodule Thinktank.Engine do
   end
 
   defp render_paths_hint(_), do: "- none specified"
+
+  defp maybe_write_planner_artifact(_output_dir, %{planner_result: nil}), do: :ok
+
+  defp maybe_write_planner_artifact(output_dir, %{planner_result: planner_result}) do
+    output =
+      case planner_result.status do
+        :ok ->
+          planner_result.output
+
+        :error ->
+          planner_result.output <>
+            if(planner_result.error, do: "\n\nERROR: #{inspect(planner_result.error)}", else: "")
+      end
+
+    RunStore.write_text_artifact(output_dir, "review-planner", "review/planner.md", output)
+  end
 
   defp valid_input_text?(value) when is_binary(value), do: String.trim(value) != ""
   defp valid_input_text?(_), do: false

--- a/lib/thinktank/engine.ex
+++ b/lib/thinktank/engine.ex
@@ -322,15 +322,13 @@ defmodule Thinktank.Engine do
        ) do
     selected_agents = Map.get(contract.input, "agents", [])
 
-    cond do
-      selected_agents != [] ->
-        Planner.manual(agents)
-
-      true ->
-        Planner.create(planner, agents, contract, review_context, config,
-          agent_config_dir: opts[:agent_config_dir],
-          runner: opts[:runner]
-        )
+    if selected_agents != [] do
+      Planner.manual(agents)
+    else
+      Planner.create(planner, agents, contract, review_context, config,
+        agent_config_dir: opts[:agent_config_dir],
+        runner: opts[:runner]
+      )
     end
   end
 

--- a/lib/thinktank/executor/agentic.ex
+++ b/lib/thinktank/executor/agentic.ex
@@ -84,6 +84,7 @@ defmodule Thinktank.Executor.Agentic do
       |> Template.render(
         contract.input
         |> Map.merge(context)
+        |> Map.merge(stringify_keys(agent.metadata))
         |> Map.merge(%{
           "agent_name" => agent.name,
           "bench_id" => contract.bench_id,

--- a/lib/thinktank/review/context.ex
+++ b/lib/thinktank/review/context.ex
@@ -1,0 +1,337 @@
+defmodule Thinktank.Review.Context do
+  @moduledoc false
+
+  @max_files 200
+
+  @type t :: map()
+
+  @spec capture(String.t(), map(), keyword()) :: t()
+  def capture(workspace_root, input, opts \\ [])
+      when is_binary(workspace_root) and is_map(input) do
+    git_runner = Keyword.get(opts, :git_runner, &default_git_runner/2)
+
+    if git_available?(workspace_root, git_runner) do
+      build_git_context(workspace_root, stringify_keys(input), git_runner)
+    else
+      unavailable_context(workspace_root)
+    end
+  end
+
+  @spec render(t()) :: String.t()
+  def render(context) when is_map(context) do
+    git = Map.get(context, "git", %{})
+    change = Map.get(context, "change", %{})
+    signals = Map.get(change, "signals", %{})
+    line_stats = Map.get(change, "line_stats", %{})
+
+    files =
+      change
+      |> Map.get("files", [])
+      |> Enum.take(12)
+
+    file_lines =
+      case files do
+        [] -> "- none"
+        list -> Enum.map_join(list, "\n", &"- #{&1}")
+      end
+
+    """
+    Review context:
+    - Git context available: #{yes_no(git["available"])}
+    - Branch: #{git["branch"] || "unknown"}
+    - Diff scope: #{git["range"] || "workspace changes"}
+    - Files changed: #{change["file_count"] || 0}
+    - Directories changed: #{change["directory_count"] || 0}
+    - Line churn: +#{line_stats["added"] || 0} / -#{line_stats["deleted"] || 0}
+
+    Change signals:
+    - touches_code: #{yes_no(signals["touches_code"])}
+    - touches_tests: #{yes_no(signals["touches_tests"])}
+    - touches_docs: #{yes_no(signals["touches_docs"])}
+    - touches_ci: #{yes_no(signals["touches_ci"])}
+    - touches_dependencies: #{yes_no(signals["touches_dependencies"])}
+    - touches_security_surface: #{yes_no(signals["touches_security_surface"])}
+
+    Changed files (sample):
+    #{file_lines}
+    """
+    |> String.trim()
+  end
+
+  defp build_git_context(workspace_root, input, git_runner) do
+    base = present_string(input["base"])
+    head = present_string(input["head"]) || "HEAD"
+    range = if(base, do: "#{base}...#{head}", else: nil)
+
+    {files, file_warnings} = collect_files(workspace_root, range, git_runner)
+    {line_stats, line_warnings} = collect_line_stats(workspace_root, range, git_runner)
+
+    directories =
+      files
+      |> Enum.map(&top_directory/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.uniq()
+
+    warnings = file_warnings ++ line_warnings
+
+    %{
+      "version" => 1,
+      "git" => %{
+        "available" => true,
+        "branch" => git_output(workspace_root, ~w(rev-parse --abbrev-ref HEAD), git_runner),
+        "head_sha" => git_output(workspace_root, ~w(rev-parse HEAD), git_runner),
+        "base" => base,
+        "head" => head,
+        "range" => range,
+        "merge_base" => merge_base(workspace_root, base, head, git_runner)
+      },
+      "change" => %{
+        "file_count" => length(files),
+        "directory_count" => length(directories),
+        "directories" => directories,
+        "files" => Enum.take(files, @max_files),
+        "files_truncated" => length(files) > @max_files,
+        "line_stats" => line_stats,
+        "signals" => change_signals(files)
+      },
+      "warnings" => warnings
+    }
+  end
+
+  defp unavailable_context(workspace_root) do
+    %{
+      "version" => 1,
+      "git" => %{
+        "available" => false,
+        "branch" => nil,
+        "head_sha" => nil,
+        "base" => nil,
+        "head" => nil,
+        "range" => nil,
+        "merge_base" => nil
+      },
+      "change" => %{
+        "file_count" => 0,
+        "directory_count" => 0,
+        "directories" => [],
+        "files" => [],
+        "files_truncated" => false,
+        "line_stats" => %{"added" => 0, "deleted" => 0, "binary_files" => 0},
+        "signals" => empty_signals()
+      },
+      "warnings" => ["git context unavailable for #{workspace_root}"]
+    }
+  end
+
+  defp collect_files(workspace_root, nil, git_runner) do
+    {tracked, tracked_warnings} =
+      git_lines(workspace_root, ~w(diff --name-only --diff-filter=ACMRTUXB HEAD), git_runner)
+
+    {untracked, untracked_warnings} =
+      git_lines(workspace_root, ~w(ls-files --others --exclude-standard), git_runner)
+
+    {Enum.uniq(tracked ++ untracked), tracked_warnings ++ untracked_warnings}
+  end
+
+  defp collect_files(workspace_root, range, git_runner) do
+    args = ["diff", "--name-only", "--diff-filter=ACMRTUXB", range]
+
+    case git_output(workspace_root, args, git_runner, with_status: true) do
+      {:ok, output} ->
+        files = output |> String.split("\n", trim: true) |> Enum.uniq()
+        {files, []}
+
+      {:error, reason} ->
+        collect_files(workspace_root, nil, git_runner)
+        |> then(fn {files, warnings} ->
+          {files, ["failed to inspect diff range #{range}: #{reason}" | warnings]}
+        end)
+    end
+  end
+
+  defp collect_line_stats(workspace_root, nil, git_runner) do
+    case git_output(workspace_root, ~w(diff --numstat HEAD), git_runner, with_status: true) do
+      {:ok, output} -> {parse_numstat(output), []}
+      {:error, reason} -> {%{"added" => 0, "deleted" => 0, "binary_files" => 0}, [reason]}
+    end
+  end
+
+  defp collect_line_stats(workspace_root, range, git_runner) do
+    args = ["diff", "--numstat", range]
+
+    case git_output(workspace_root, args, git_runner, with_status: true) do
+      {:ok, output} ->
+        {parse_numstat(output), []}
+
+      {:error, reason} ->
+        collect_line_stats(workspace_root, nil, git_runner)
+        |> then(fn {stats, warnings} ->
+          {stats, ["failed to collect line stats for #{range}: #{reason}" | warnings]}
+        end)
+    end
+  end
+
+  defp parse_numstat(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.reduce(%{"added" => 0, "deleted" => 0, "binary_files" => 0}, fn line, acc ->
+      case String.split(line, "\t", parts: 3) do
+        [added, deleted, _path] ->
+          acc
+          |> Map.update!("added", &(&1 + parse_numstat_number(added)))
+          |> Map.update!("deleted", &(&1 + parse_numstat_number(deleted)))
+          |> Map.update!("binary_files", fn count ->
+            if added == "-" or deleted == "-", do: count + 1, else: count
+          end)
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp parse_numstat_number("-"), do: 0
+
+  defp parse_numstat_number(value) do
+    case Integer.parse(value) do
+      {number, ""} -> number
+      _ -> 0
+    end
+  end
+
+  defp change_signals(files) do
+    %{
+      "touches_code" => Enum.any?(files, &code_path?/1),
+      "touches_tests" => Enum.any?(files, &test_path?/1),
+      "touches_docs" => Enum.any?(files, &docs_path?/1),
+      "touches_ci" => Enum.any?(files, &ci_path?/1),
+      "touches_dependencies" => Enum.any?(files, &dependency_path?/1),
+      "touches_security_surface" => Enum.any?(files, &security_path?/1)
+    }
+  end
+
+  defp empty_signals do
+    %{
+      "touches_code" => false,
+      "touches_tests" => false,
+      "touches_docs" => false,
+      "touches_ci" => false,
+      "touches_dependencies" => false,
+      "touches_security_surface" => false
+    }
+  end
+
+  defp code_path?(path), do: String.starts_with?(path, "lib/")
+
+  defp test_path?(path) do
+    String.starts_with?(path, "test/") or
+      String.starts_with?(path, "spec/") or
+      String.contains?(path, "/test/") or
+      String.contains?(path, "/tests/") or
+      String.ends_with?(path, "_test.exs")
+  end
+
+  defp docs_path?(path) do
+    String.starts_with?(path, "docs/") or
+      String.starts_with?(path, "doc/") or
+      String.starts_with?(path, "README") or
+      String.ends_with?(path, ".md")
+  end
+
+  defp ci_path?(path) do
+    String.starts_with?(path, ".github/workflows/") or
+      String.starts_with?(path, ".circleci/") or
+      path == "Dockerfile" or
+      String.starts_with?(path, "ci/")
+  end
+
+  defp dependency_path?(path) do
+    path in [
+      "mix.exs",
+      "mix.lock",
+      "package.json",
+      "pnpm-lock.yaml",
+      "yarn.lock",
+      "go.mod",
+      "go.sum"
+    ]
+  end
+
+  defp security_path?(path) do
+    lower = String.downcase(path)
+
+    Enum.any?(
+      ["auth", "token", "secret", "oauth", "crypto", "permission", "acl", "policy"],
+      fn marker ->
+        String.contains?(lower, marker)
+      end
+    )
+  end
+
+  defp top_directory(path) do
+    path
+    |> String.split("/", parts: 2)
+    |> List.first()
+    |> to_string()
+  end
+
+  defp merge_base(_workspace_root, nil, _head, _git_runner), do: nil
+
+  defp merge_base(workspace_root, base, head, git_runner) do
+    git_output(workspace_root, ["merge-base", base, head], git_runner)
+  end
+
+  defp git_available?(workspace_root, git_runner) do
+    case git_output(workspace_root, ~w(rev-parse --is-inside-work-tree), git_runner,
+           with_status: true
+         ) do
+      {:ok, "true"} -> true
+      _ -> false
+    end
+  end
+
+  defp git_output(workspace_root, args, git_runner, opts \\ []) do
+    {output, exit_code} = git_runner.(workspace_root, args)
+    trimmed = String.trim(output)
+
+    if opts[:with_status] do
+      if exit_code == 0 do
+        {:ok, trimmed}
+      else
+        {:error, "git #{Enum.join(args, " ")} failed (#{exit_code}): #{trimmed}"}
+      end
+    else
+      if exit_code == 0, do: trimmed, else: nil
+    end
+  end
+
+  defp default_git_runner(workspace_root, args) do
+    System.cmd("git", args, cd: workspace_root, stderr_to_stdout: true)
+  end
+
+  defp git_lines(workspace_root, args, git_runner) do
+    case git_output(workspace_root, args, git_runner, with_status: true) do
+      {:ok, output} ->
+        {String.split(output, "\n", trim: true), []}
+
+      {:error, reason} ->
+        {[], [reason]}
+    end
+  end
+
+  defp stringify_keys(map) do
+    map
+    |> Enum.map(fn {key, value} -> {to_string(key), value} end)
+    |> Enum.into(%{})
+  end
+
+  defp present_string(value) when is_binary(value) do
+    trimmed = String.trim(value)
+    if trimmed == "", do: nil, else: trimmed
+  end
+
+  defp present_string(_), do: nil
+
+  defp yes_no(true), do: "yes"
+  defp yes_no(_), do: "no"
+end

--- a/lib/thinktank/review/context.ex
+++ b/lib/thinktank/review/context.ex
@@ -174,20 +174,7 @@ defmodule Thinktank.Review.Context do
   defp parse_numstat(output) do
     output
     |> String.split("\n", trim: true)
-    |> Enum.reduce(%{"added" => 0, "deleted" => 0, "binary_files" => 0}, fn line, acc ->
-      case String.split(line, "\t", parts: 3) do
-        [added, deleted, _path] ->
-          acc
-          |> Map.update!("added", &(&1 + parse_numstat_number(added)))
-          |> Map.update!("deleted", &(&1 + parse_numstat_number(deleted)))
-          |> Map.update!("binary_files", fn count ->
-            if added == "-" or deleted == "-", do: count + 1, else: count
-          end)
-
-        _ ->
-          acc
-      end
-    end)
+    |> Enum.reduce(%{"added" => 0, "deleted" => 0, "binary_files" => 0}, &accumulate_numstat/2)
   end
 
   defp parse_numstat_number("-"), do: 0
@@ -198,6 +185,27 @@ defmodule Thinktank.Review.Context do
       _ -> 0
     end
   end
+
+  defp accumulate_numstat(line, acc) do
+    case String.split(line, "\t", parts: 3) do
+      [added, deleted, _path] ->
+        update_numstat(acc, added, deleted)
+
+      _ ->
+        acc
+    end
+  end
+
+  defp update_numstat(acc, added, deleted) do
+    acc
+    |> Map.update!("added", &(&1 + parse_numstat_number(added)))
+    |> Map.update!("deleted", &(&1 + parse_numstat_number(deleted)))
+    |> Map.update!("binary_files", &(&1 + binary_file_increment(added, deleted)))
+  end
+
+  defp binary_file_increment("-", _deleted), do: 1
+  defp binary_file_increment(_added, "-"), do: 1
+  defp binary_file_increment(_added, _deleted), do: 0
 
   defp change_signals(files) do
     %{

--- a/lib/thinktank/review/eval.ex
+++ b/lib/thinktank/review/eval.ex
@@ -1,0 +1,133 @@
+defmodule Thinktank.Review.Eval do
+  @moduledoc false
+
+  alias Thinktank.{Engine, RunContract}
+
+  @type result :: %{
+          target: String.t(),
+          status: String.t(),
+          output_dir: String.t(),
+          cases: [map()]
+        }
+
+  @spec run(String.t(), keyword()) :: {:ok, result()} | {:error, term()}
+  def run(target, opts \\ []) when is_binary(target) do
+    with {:ok, contract_paths} <- contract_paths(target),
+         {:ok, contracts} <- load_contracts(contract_paths) do
+      output_dir = Keyword.get(opts, :output, Engine.generate_output_dir("review-eval"))
+
+      cases =
+        contracts
+        |> Enum.with_index(1)
+        |> Enum.map(fn {{contract_path, contract}, index} ->
+          run_case(index, contract_path, contract, output_dir, opts)
+        end)
+
+      {:ok,
+       %{
+         target: target,
+         status: derive_status(cases),
+         output_dir: output_dir,
+         cases: cases
+       }}
+    end
+  end
+
+  defp run_case(index, contract_path, contract, output_dir, opts) do
+    bench_id = Keyword.get(opts, :bench_id, contract.bench_id)
+    case_id = "case-#{String.pad_leading(Integer.to_string(index), 3, "0")}"
+    case_output = Path.join(output_dir, case_id)
+
+    run_opts =
+      [cwd: contract.workspace_root, output: case_output]
+      |> maybe_put_opt(:trust_repo_config, Keyword.get(opts, :trust_repo_config))
+      |> maybe_put_opt(
+        :agent_config_dir,
+        Keyword.get(opts, :agent_config_dir) || agent_config_dir(contract.workspace_root)
+      )
+      |> maybe_put_opt(:runner, Keyword.get(opts, :runner))
+
+    case Engine.run(bench_id, contract.input, run_opts) do
+      {:ok, result} ->
+        %{
+          case_id: case_id,
+          contract: contract_path,
+          bench: bench_id,
+          status: result.envelope.status,
+          output_dir: result.output_dir
+        }
+
+      {:error, reason, failed_output_dir} ->
+        %{
+          case_id: case_id,
+          contract: contract_path,
+          bench: bench_id,
+          status: "failed",
+          output_dir: failed_output_dir || case_output,
+          error: format_reason(reason)
+        }
+    end
+  end
+
+  defp contract_paths(target) do
+    expanded = Path.expand(target)
+
+    cond do
+      File.regular?(expanded) ->
+        {:ok, [expanded]}
+
+      File.dir?(expanded) ->
+        case Path.wildcard(Path.join(expanded, "**/contract.json")) |> Enum.sort() do
+          [] -> {:error, "no contract.json files found under #{expanded}"}
+          paths -> {:ok, paths}
+        end
+
+      true ->
+        {:error, "path does not exist: #{expanded}"}
+    end
+  end
+
+  defp load_contracts(paths) do
+    Enum.reduce_while(paths, {:ok, []}, fn path, {:ok, acc} ->
+      with {:ok, raw} <- File.read(path),
+           {:ok, decoded} <- Jason.decode(raw),
+           {:ok, contract} <- RunContract.from_map(decoded) do
+        {:cont, {:ok, [{path, contract} | acc]}}
+      else
+        {:error, reason} ->
+          {:halt, {:error, "failed to load #{path}: #{inspect(reason)}"}}
+      end
+    end)
+    |> case do
+      {:ok, contracts} -> {:ok, Enum.reverse(contracts)}
+      error -> error
+    end
+  end
+
+  defp derive_status(cases) do
+    statuses = Enum.map(cases, & &1.status)
+
+    cond do
+      Enum.all?(statuses, &(&1 == "complete")) -> "complete"
+      Enum.any?(statuses, &(&1 in ["complete", "degraded"])) -> "degraded"
+      true -> "failed"
+    end
+  end
+
+  defp maybe_put_opt(opts, _key, nil), do: opts
+  defp maybe_put_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp agent_config_dir(workspace_root) do
+    if trust_repo_agent_config?() do
+      dir = Path.join(workspace_root, "agent_config")
+      if File.dir?(dir), do: dir
+    end
+  end
+
+  defp format_reason(reason) when is_binary(reason), do: reason
+  defp format_reason(reason), do: inspect(reason)
+
+  defp trust_repo_agent_config? do
+    System.get_env("THINKTANK_TRUST_REPO_AGENT_CONFIG") in ["1", "true", "TRUE", "yes", "YES"]
+  end
+end

--- a/lib/thinktank/review/eval.ex
+++ b/lib/thinktank/review/eval.ex
@@ -1,7 +1,7 @@
 defmodule Thinktank.Review.Eval do
   @moduledoc false
 
-  alias Thinktank.{Engine, RunContract}
+  alias Thinktank.{Config, Engine, RunContract}
 
   @type result :: %{
           target: String.t(),
@@ -118,7 +118,7 @@ defmodule Thinktank.Review.Eval do
   defp maybe_put_opt(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp agent_config_dir(workspace_root) do
-    if trust_repo_agent_config?() do
+    if Config.trust_repo_agent_config?() do
       dir = Path.join(workspace_root, "agent_config")
       if File.dir?(dir), do: dir
     end
@@ -126,8 +126,4 @@ defmodule Thinktank.Review.Eval do
 
   defp format_reason(reason) when is_binary(reason), do: reason
   defp format_reason(reason), do: inspect(reason)
-
-  defp trust_repo_agent_config? do
-    System.get_env("THINKTANK_TRUST_REPO_AGENT_CONFIG") in ["1", "true", "TRUE", "yes", "YES"]
-  end
 end

--- a/lib/thinktank/review/planner.ex
+++ b/lib/thinktank/review/planner.ex
@@ -3,6 +3,7 @@ defmodule Thinktank.Review.Planner do
 
   alias Thinktank.{AgentSpec, Config, RunContract}
   alias Thinktank.Executor.Agentic
+  alias Thinktank.Review.Context
 
   @type plan :: map()
   @type outcome :: %{plan: plan(), planner_result: Agentic.result() | nil}
@@ -28,7 +29,7 @@ defmodule Thinktank.Review.Planner do
   def create(planner, agents, contract, review_context, config, opts) do
     context = %{
       "paths_hint" => render_paths_hint(contract.input),
-      "review_context" => Thinktank.Review.Context.render(review_context),
+      "review_context" => Context.render(review_context),
       "review_roster" => render_roster(agents)
     }
 
@@ -71,26 +72,13 @@ defmodule Thinktank.Review.Planner do
     selected =
       plan
       |> Map.get("selected_agents", [])
-      |> Enum.reduce([], fn agent_plan, acc ->
-        case {trimmed_string(agent_plan["name"]), trimmed_string(agent_plan["brief"])} do
-          {nil, _brief} ->
-            acc
+      |> Enum.map(&planned_agent(&1, indexed_agents))
+      |> Enum.reject(&is_nil/1)
 
-          {name, brief} ->
-            case Map.get(indexed_agents, name) do
-              nil -> acc
-              agent -> [attach_brief(agent, brief || default_brief(agent)) | acc]
-            end
-        end
-      end)
-      |> Enum.reverse()
-
-    case selected do
-      [] ->
-        Enum.map(agents, &attach_brief(&1, default_brief(&1)))
-
-      planned ->
-        planned
+    if selected == [] do
+      Enum.map(agents, &attach_brief(&1, default_brief(&1)))
+    else
+      selected
     end
   end
 
@@ -188,7 +176,7 @@ defmodule Thinktank.Review.Planner do
           nil
       end
 
-    [trimmed, fenced && List.first(fenced), brace_candidate]
+    [fenced && List.first(fenced), brace_candidate, trimmed]
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
   end
@@ -258,6 +246,19 @@ defmodule Thinktank.Review.Planner do
 
   defp attach_brief(agent, brief) do
     %{agent | metadata: Map.put(agent.metadata, "review_brief", brief)}
+  end
+
+  defp planned_agent(agent_plan, indexed_agents) do
+    case {trimmed_string(agent_plan["name"]), trimmed_string(agent_plan["brief"])} do
+      {nil, _brief} ->
+        nil
+
+      {name, brief} ->
+        case Map.get(indexed_agents, name) do
+          nil -> nil
+          agent -> attach_brief(agent, brief || default_brief(agent))
+        end
+    end
   end
 
   defp default_brief(%AgentSpec{} = agent) do

--- a/lib/thinktank/review/planner.ex
+++ b/lib/thinktank/review/planner.ex
@@ -282,7 +282,6 @@ defmodule Thinktank.Review.Planner do
 
   defp format_error(nil), do: "unknown error"
   defp format_error(error) when is_map(error), do: inspect(error)
-  defp format_error(error), do: to_string(error)
 
   defp render_paths_hint(input) when is_map(input) do
     case Map.get(input, "paths", []) do

--- a/lib/thinktank/review/planner.ex
+++ b/lib/thinktank/review/planner.ex
@@ -1,0 +1,313 @@
+defmodule Thinktank.Review.Planner do
+  @moduledoc false
+
+  alias Thinktank.{AgentSpec, Config, RunContract}
+  alias Thinktank.Executor.Agentic
+
+  @type plan :: map()
+  @type outcome :: %{plan: plan(), planner_result: Agentic.result() | nil}
+
+  @spec manual([AgentSpec.t()]) :: outcome()
+  def manual(agents) do
+    %{plan: default_plan(agents, "manual"), planner_result: nil}
+  end
+
+  @spec create(
+          AgentSpec.t() | nil,
+          [AgentSpec.t()],
+          RunContract.t(),
+          map(),
+          Config.t(),
+          keyword()
+        ) ::
+          outcome()
+  def create(nil, agents, _contract, _review_context, _config, _opts) do
+    %{plan: default_plan(agents, "fallback"), planner_result: nil}
+  end
+
+  def create(planner, agents, contract, review_context, config, opts) do
+    context = %{
+      "paths_hint" => render_paths_hint(contract.input),
+      "review_context" => Thinktank.Review.Context.render(review_context),
+      "review_roster" => render_roster(agents)
+    }
+
+    [planner_result] =
+      Agentic.run([planner], contract, context, config,
+        concurrency: 1,
+        agent_config_dir: opts[:agent_config_dir],
+        runner: opts[:runner]
+      )
+
+    plan =
+      case planner_result.status do
+        :ok ->
+          case parse_plan(planner_result.output, agents) do
+            {:ok, parsed} ->
+              parsed
+
+            {:error, reason} ->
+              default_plan(agents, "fallback", [
+                "planner output could not be parsed: #{reason}"
+              ])
+          end
+
+        :error ->
+          default_plan(agents, "fallback", [
+            "planner failed: #{format_error(planner_result.error)}"
+          ])
+      end
+
+    %{plan: plan, planner_result: planner_result}
+  end
+
+  @spec apply_plan(plan(), [AgentSpec.t()]) :: [AgentSpec.t()]
+  def apply_plan(plan, agents) do
+    indexed_agents =
+      agents
+      |> Enum.map(&{&1.name, &1})
+      |> Map.new()
+
+    selected =
+      plan
+      |> Map.get("selected_agents", [])
+      |> Enum.reduce([], fn agent_plan, acc ->
+        case {trimmed_string(agent_plan["name"]), trimmed_string(agent_plan["brief"])} do
+          {nil, _brief} ->
+            acc
+
+          {name, brief} ->
+            case Map.get(indexed_agents, name) do
+              nil -> acc
+              agent -> [attach_brief(agent, brief || default_brief(agent)) | acc]
+            end
+        end
+      end)
+      |> Enum.reverse()
+
+    case selected do
+      [] ->
+        Enum.map(agents, &attach_brief(&1, default_brief(&1)))
+
+      planned ->
+        planned
+    end
+  end
+
+  @spec render(plan()) :: String.t()
+  def render(plan) do
+    reviewers =
+      case Map.get(plan, "selected_agents", []) do
+        [] ->
+          "- none"
+
+        selected ->
+          Enum.map_join(selected, "\n", fn agent ->
+            name = agent["name"] || "unknown"
+            brief = agent["brief"] || ""
+            "- #{name}: #{brief}"
+          end)
+      end
+
+    warnings =
+      case Map.get(plan, "warnings", []) do
+        [] -> "- none"
+        items -> Enum.map_join(items, "\n", &"- #{&1}")
+      end
+
+    """
+    Review plan:
+    - Source: #{Map.get(plan, "source", "unknown")}
+    - Summary: #{Map.get(plan, "summary", "No planner summary provided.")}
+    - Synth brief: #{Map.get(plan, "synthesis_brief", "Use reviewer evidence and suppress overlap.")}
+
+    Selected reviewers:
+    #{reviewers}
+
+    Warnings:
+    #{warnings}
+    """
+    |> String.trim()
+  end
+
+  defp parse_plan(raw_output, agents) when is_binary(raw_output) do
+    allowed = MapSet.new(Enum.map(agents, & &1.name))
+
+    with {:ok, decoded} <- decode_plan(raw_output),
+         {:ok, selected} <- parse_selected_agents(decoded["selected_agents"], allowed),
+         false <- selected == [] do
+      {:ok,
+       %{
+         "version" => 1,
+         "source" => "planner",
+         "summary" =>
+           trimmed_string(decoded["summary"]) ||
+             "Planner selected the reviewer team for this change.",
+         "selected_agents" => selected,
+         "synthesis_brief" =>
+           trimmed_string(decoded["synthesis_brief"]) ||
+             "Prioritize grounded findings and collapse duplicates.",
+         "warnings" => parse_warnings(decoded["warnings"])
+       }}
+    else
+      true ->
+        {:error, "planner selected no reviewers"}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp decode_plan(raw_output) do
+    raw_output
+    |> candidate_json_strings()
+    |> Enum.reduce_while({:error, "planner did not return valid JSON"}, fn candidate, _acc ->
+      case Jason.decode(candidate) do
+        {:ok, %{} = decoded} -> {:halt, {:ok, decoded}}
+        _ -> {:cont, {:error, "planner did not return valid JSON"}}
+      end
+    end)
+  end
+
+  defp candidate_json_strings(raw_output) do
+    trimmed = String.trim(raw_output)
+    fenced = Regex.run(~r/```(?:json)?\s*(\{.*\})\s*```/s, raw_output, capture: :all_but_first)
+
+    brace_candidate =
+      case {first_index(raw_output, "{"), last_index(raw_output, "}")} do
+        {nil, _} ->
+          nil
+
+        {_, nil} ->
+          nil
+
+        {start_index, end_index} when end_index >= start_index ->
+          String.slice(raw_output, start_index..end_index)
+
+        _ ->
+          nil
+      end
+
+    [trimmed, fenced && List.first(fenced), brace_candidate]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp parse_selected_agents(selected_agents, allowed) when is_list(selected_agents) do
+    parsed =
+      selected_agents
+      |> Enum.reduce([], fn entry, acc ->
+        case parse_selected_agent(entry, allowed) do
+          nil -> acc
+          parsed_entry -> [parsed_entry | acc]
+        end
+      end)
+      |> Enum.reverse()
+
+    {:ok, parsed}
+  end
+
+  defp parse_selected_agents(_, _allowed), do: {:error, "selected_agents must be a list"}
+
+  defp parse_selected_agent(%{} = entry, allowed) do
+    with name when not is_nil(name) <- trimmed_string(entry["name"]),
+         true <- MapSet.member?(allowed, name) do
+      %{
+        "name" => name,
+        "brief" => trimmed_string(entry["brief"]) || default_brief(name)
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  defp parse_selected_agent(_, _allowed), do: nil
+
+  defp parse_warnings(warnings) when is_list(warnings) do
+    warnings
+    |> Enum.map(&trimmed_string/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp parse_warnings(_), do: []
+
+  defp default_plan(agents, source, warnings \\ []) do
+    %{
+      "version" => 1,
+      "source" => source,
+      "summary" => "Use the bench defaults for this review run.",
+      "selected_agents" =>
+        Enum.map(agents, fn agent ->
+          %{
+            "name" => agent.name,
+            "brief" => default_brief(agent)
+          }
+        end),
+      "synthesis_brief" => "Prioritize grounded findings and collapse duplicates.",
+      "warnings" => warnings
+    }
+  end
+
+  defp render_roster(agents) do
+    Enum.map_join(agents, "\n", fn agent ->
+      role = get_in(agent.metadata, ["review_role"]) || "reviewer"
+      summary = first_sentence(agent.system_prompt)
+      "- #{agent.name} (#{role}, #{agent.model}): #{summary}"
+    end)
+  end
+
+  defp attach_brief(agent, brief) do
+    %{agent | metadata: Map.put(agent.metadata, "review_brief", brief)}
+  end
+
+  defp default_brief(%AgentSpec{} = agent) do
+    role = get_in(agent.metadata, ["review_role"]) || "review"
+    "Focus on the highest-signal #{role} risks in the change and report only grounded issues."
+  end
+
+  defp default_brief(name) when is_binary(name) do
+    "Focus on the highest-signal risks relevant to #{name} and report only grounded issues."
+  end
+
+  defp first_sentence(text) when is_binary(text) do
+    text
+    |> String.split(~r/(?<=[.!?])\s+/, parts: 2)
+    |> List.first()
+    |> to_string()
+    |> String.trim()
+  end
+
+  defp first_sentence(_), do: ""
+
+  defp format_error(nil), do: "unknown error"
+  defp format_error(error) when is_map(error), do: inspect(error)
+  defp format_error(error), do: to_string(error)
+
+  defp render_paths_hint(input) when is_map(input) do
+    case Map.get(input, "paths", []) do
+      [] -> "- none specified"
+      paths -> Enum.map_join(paths, "\n", &"- #{&1}")
+    end
+  end
+
+  defp trimmed_string(value) when is_binary(value) do
+    value = String.trim(value)
+    if value == "", do: nil, else: value
+  end
+
+  defp trimmed_string(_), do: nil
+
+  defp first_index(haystack, needle) when is_binary(haystack) and is_binary(needle) do
+    case :binary.match(haystack, needle) do
+      {index, _length} -> index
+      :nomatch -> nil
+    end
+  end
+
+  defp last_index(haystack, needle) when is_binary(haystack) and is_binary(needle) do
+    case :binary.matches(haystack, needle) do
+      [] -> nil
+      matches -> matches |> List.last() |> elem(0)
+    end
+  end
+end

--- a/lib/thinktank/run_store.ex
+++ b/lib/thinktank/run_store.ex
@@ -81,6 +81,15 @@ defmodule Thinktank.RunStore do
     end)
   end
 
+  @spec set_planned_agents(Path.t(), [String.t()]) :: :ok
+  def set_planned_agents(output_dir, planned_agents) when is_list(planned_agents) do
+    names = Enum.filter(planned_agents, &is_binary/1)
+
+    update_manifest(output_dir, fn manifest ->
+      %{manifest | "planned_agents" => names}
+    end)
+  end
+
   @spec result_envelope(Path.t()) :: map()
   def result_envelope(output_dir) do
     manifest = read_manifest(output_dir)

--- a/test/thinktank/bench_spec_test.exs
+++ b/test/thinktank/bench_spec_test.exs
@@ -9,6 +9,7 @@ defmodule Thinktank.BenchSpecTest do
                "kind" => "review",
                "description" => "Review bench",
                "agents" => ["trace", "guard"],
+               "planner" => "marshal",
                "synthesizer" => "review-synth",
                "concurrency" => "2",
                "default_task" => "Review this"
@@ -17,6 +18,7 @@ defmodule Thinktank.BenchSpecTest do
     assert bench.id == "review/cerberus"
     assert bench.kind == :review
     assert bench.agents == ["trace", "guard"]
+    assert bench.planner == "marshal"
     assert bench.synthesizer == "review-synth"
     assert bench.concurrency == 2
   end

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -67,6 +67,23 @@ defmodule Thinktank.CLITest do
     assert command.input.pr == 42
   end
 
+  test "parses review eval command" do
+    assert {:ok, command} =
+             CLI.parse_args([
+               "review",
+               "eval",
+               "./tmp/review-run",
+               "--bench",
+               "review/constellation",
+               "--json"
+             ])
+
+    assert command.action == :review_eval
+    assert command.target == Path.expand("./tmp/review-run")
+    assert command.bench_id == "review/constellation"
+    assert command.json == true
+  end
+
   test "requires --repo when --pr is provided for review" do
     assert {:error, "review/cerberus requires --repo when --pr is provided"} =
              CLI.parse_args(["review", "--pr", "42"])
@@ -250,6 +267,19 @@ defmodule Thinktank.CLITest do
     assert output =~ "Bench: research/default"
     assert output =~ "Description:"
     assert output =~ "Input: test prompt"
+  end
+
+  test "dry run JSON includes planner metadata for review benches" do
+    {:ok, command} = CLI.parse_args(["review", "--dry-run", "--json"])
+
+    output =
+      capture_io(fn ->
+        assert CLI.execute({:ok, command}) == 0
+      end)
+
+    assert {:ok, decoded} = Jason.decode(String.trim(output))
+    assert decoded["bench"] == "review/cerberus"
+    assert decoded["planner"] == "marshal"
   end
 
   test "uses env trust for repo config when the flag is omitted" do

--- a/test/thinktank/config_test.exs
+++ b/test/thinktank/config_test.exs
@@ -18,9 +18,12 @@ defmodule Thinktank.ConfigTest do
     assert Map.has_key?(config.providers, "openrouter")
     assert Map.has_key?(config.benches, "research/default")
     assert Map.has_key?(config.benches, "review/cerberus")
+    assert Map.has_key?(config.benches, "review/constellation")
+    assert Map.has_key?(config.agents, "marshal")
     assert Map.has_key?(config.agents, "trace")
     assert config.benches["research/default"].kind == :research
     assert config.benches["review/cerberus"].kind == :review
+    assert config.benches["review/cerberus"].planner == "marshal"
   end
 
   test "repo config overrides user config and adds benches when trusted" do

--- a/test/thinktank/engine_test.exs
+++ b/test/thinktank/engine_test.exs
@@ -206,19 +206,17 @@ defmodule Thinktank.EngineTest do
     runner = fn _cmd, args, _opts ->
       prompt = File.read!(prompt_path(args))
 
-      cond do
-        String.contains?(prompt, "Return JSON only with this shape:") ->
-          {Jason.encode!(%{
-             "summary" => "Keep the bench focused on correctness and architecture.",
-             "selected_agents" => [
-               %{"name" => "trace", "brief" => "Check behavioral regressions."},
-               %{"name" => "atlas", "brief" => "Check boundary and coupling changes."}
-             ],
-             "synthesis_brief" => "Prefer grounded defects."
-           }), 0}
-
-        true ->
-          {"ok", 0}
+      if String.contains?(prompt, "Return JSON only with this shape:") do
+        {Jason.encode!(%{
+           "summary" => "Keep the bench focused on correctness and architecture.",
+           "selected_agents" => [
+             %{"name" => "trace", "brief" => "Check behavioral regressions."},
+             %{"name" => "atlas", "brief" => "Check boundary and coupling changes."}
+           ],
+           "synthesis_brief" => "Prefer grounded defects."
+         }), 0}
+      else
+        {"ok", 0}
       end
     end
 

--- a/test/thinktank/engine_test.exs
+++ b/test/thinktank/engine_test.exs
@@ -14,6 +14,19 @@ defmodule Thinktank.EngineTest do
     args |> Enum.at(index + 1) |> String.trim_leading("@")
   end
 
+  defp git!(cwd, args) do
+    case System.cmd("git", args, cd: cwd, stderr_to_stdout: true) do
+      {output, 0} -> output
+      {output, status} -> flunk("git #{Enum.join(args, " ")} failed (#{status}): #{output}")
+    end
+  end
+
+  defp init_git_repo!(cwd) do
+    git!(cwd, ["init"])
+    git!(cwd, ["config", "user.email", "thinktank@example.com"])
+    git!(cwd, ["config", "user.name", "ThinkTank Test"])
+  end
+
   test "runs a bench, records raw agent outputs, and writes a synthesized summary" do
     cwd = unique_tmp_dir("thinktank-engine")
 
@@ -21,10 +34,26 @@ defmodule Thinktank.EngineTest do
       path = prompt_path(args)
       prompt = File.read!(path)
 
-      if String.contains?(prompt, "Agent outputs:") do
-        {"Synthesized summary\n\n" <> prompt, 0}
-      else
-        {"Raw agent report\n\n" <> prompt, 0}
+      cond do
+        String.contains?(prompt, "Return JSON only with this shape:") ->
+          {Jason.encode!(%{
+             "summary" => "Focus the bench on correctness, architecture, and tests.",
+             "selected_agents" => [
+               %{
+                 "name" => "trace",
+                 "brief" => "Focus on behavioral regressions in the changed paths."
+               },
+               %{"name" => "atlas", "brief" => "Focus on coupling and boundary changes."},
+               %{"name" => "proof", "brief" => "Focus on regression coverage gaps."}
+             ],
+             "synthesis_brief" => "Prioritize reviewer overlap and grounded defects."
+           }), 0}
+
+        String.contains?(prompt, "Agent outputs:") ->
+          {"Synthesized summary\n\n" <> prompt, 0}
+
+        true ->
+          {"Raw agent report\n\n" <> prompt, 0}
       end
     end
 
@@ -46,7 +75,11 @@ defmodule Thinktank.EngineTest do
     assert result.envelope.status == "complete"
     assert File.exists?(Path.join(result.output_dir, "review.md"))
     assert File.read!(Path.join(result.output_dir, "review.md")) =~ "Synthesized summary"
-    assert Enum.count(result.results) == 4
+    assert Enum.map(result.agents, & &1.name) == ["trace", "atlas", "proof"]
+    assert Enum.count(result.results) == 3
+    assert File.exists?(Path.join(result.output_dir, "review/context.json"))
+    assert File.exists?(Path.join(result.output_dir, "review/plan.json"))
+    assert File.exists?(Path.join(result.output_dir, "review/planner.md"))
   end
 
   test "marks the run as degraded when an agent fails" do
@@ -154,6 +187,96 @@ defmodule Thinktank.EngineTest do
     assert File.exists?(Path.join(result.output_dir, "review.md"))
     assert File.read!(Path.join(result.output_dir, "review.md")) =~ "Synthesized review"
     refute File.exists?(Path.join(result.output_dir, "synthesis.md"))
+  end
+
+  test "review runs write context and plan artifacts and focus the reviewer subset" do
+    cwd = unique_tmp_dir("thinktank-engine-focused-review")
+    init_git_repo!(cwd)
+
+    File.mkdir_p!(Path.join(cwd, "lib"))
+    File.write!(Path.join(cwd, "lib/demo.ex"), "defmodule Demo do\n  def run, do: :ok\nend\n")
+    git!(cwd, ["add", "."])
+    git!(cwd, ["commit", "-m", "initial"])
+
+    File.write!(
+      Path.join(cwd, "lib/demo.ex"),
+      "defmodule Demo do\n  def run, do: :updated\nend\n"
+    )
+
+    runner = fn _cmd, args, _opts ->
+      prompt = File.read!(prompt_path(args))
+
+      cond do
+        String.contains?(prompt, "Return JSON only with this shape:") ->
+          {Jason.encode!(%{
+             "summary" => "Keep the bench focused on correctness and architecture.",
+             "selected_agents" => [
+               %{"name" => "trace", "brief" => "Check behavioral regressions."},
+               %{"name" => "atlas", "brief" => "Check boundary and coupling changes."}
+             ],
+             "synthesis_brief" => "Prefer grounded defects."
+           }), 0}
+
+        true ->
+          {"ok", 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Engine.run(
+               "review/cerberus",
+               %{input_text: "Review this branch", no_synthesis: true},
+               cwd: cwd,
+               runner: runner
+             )
+
+    assert File.exists?(Path.join(result.output_dir, "review/context.json"))
+    assert File.exists?(Path.join(result.output_dir, "review/plan.json"))
+    assert File.exists?(Path.join(result.output_dir, "review/context.md"))
+    assert File.exists?(Path.join(result.output_dir, "review/plan.md"))
+
+    plan = result.output_dir |> Path.join("review/plan.json") |> File.read!() |> Jason.decode!()
+    selected = Enum.map(plan["selected_agents"], & &1["name"])
+
+    assert selected == Enum.map(result.agents, & &1.name)
+    assert selected == ["trace", "atlas"]
+    assert Enum.member?(selected, "trace")
+    assert plan["source"] == "planner"
+
+    prompts = Path.wildcard(Path.join(result.output_dir, "prompts/*.md"))
+    assert prompts != []
+    assert Enum.any?(prompts, &(File.read!(&1) =~ "Assigned brief:"))
+  end
+
+  test "review planner preserves explicit reviewer overrides" do
+    cwd = unique_tmp_dir("thinktank-engine-explicit-review")
+    init_git_repo!(cwd)
+
+    File.mkdir_p!(Path.join(cwd, "lib"))
+    File.write!(Path.join(cwd, "lib/demo.ex"), "defmodule Demo do\n  def run, do: :ok\nend\n")
+    git!(cwd, ["add", "."])
+    git!(cwd, ["commit", "-m", "initial"])
+
+    File.write!(
+      Path.join(cwd, "lib/demo.ex"),
+      "defmodule Demo do\n  def run, do: :updated\nend\n"
+    )
+
+    runner = fn _cmd, _args, _opts -> {"ok", 0} end
+
+    assert {:ok, result} =
+             Engine.run(
+               "review/cerberus",
+               %{input_text: "Review this branch", agents: ["guard"], no_synthesis: true},
+               cwd: cwd,
+               runner: runner
+             )
+
+    assert Enum.map(result.agents, & &1.name) == ["guard"]
+
+    plan = result.output_dir |> Path.join("review/plan.json") |> File.read!() |> Jason.decode!()
+    assert plan["source"] == "manual"
+    assert Enum.map(plan["selected_agents"], & &1["name"]) == ["guard"]
   end
 
   test "does not replace malformed input_text with a bench default task" do

--- a/test/thinktank/executor/agentic_test.exs
+++ b/test/thinktank/executor/agentic_test.exs
@@ -272,4 +272,38 @@ defmodule Thinktank.Executor.AgenticTest do
 
     assert_receive {:openrouter_key, "fallback-secret"}
   end
+
+  test "renders agent metadata into the prompt context" do
+    tmp = unique_tmp_dir("thinktank-agentic-metadata")
+    test_pid = self()
+
+    agent = %AgentSpec{
+      name: "trace",
+      provider: "openrouter",
+      model: "openai/gpt-5.4",
+      system_prompt: "You are a reviewer.",
+      task_prompt: "Role={{review_role}}\nBrief={{review_brief}}",
+      timeout_ms: 5_000,
+      metadata: %{"review_role" => "correctness", "review_brief" => "Focus on regressions."}
+    }
+
+    runner = fn _cmd, args, _opts ->
+      prompt =
+        args
+        |> Enum.drop_while(&(&1 != "-p"))
+        |> Enum.at(1)
+        |> String.trim_leading("@")
+        |> File.read!()
+
+      send(test_pid, {:prompt, prompt})
+      {"ok", 0}
+    end
+
+    [result] = Agentic.run([agent], contract(tmp), %{}, config(), runner: runner)
+
+    assert result.status == :ok
+    assert_receive {:prompt, prompt}
+    assert prompt =~ "Role=correctness"
+    assert prompt =~ "Brief=Focus on regressions."
+  end
 end

--- a/test/thinktank/review/context_test.exs
+++ b/test/thinktank/review/context_test.exs
@@ -1,0 +1,49 @@
+defmodule Thinktank.Review.ContextTest do
+  use ExUnit.Case, async: true
+
+  alias Thinktank.Review.Context
+
+  defp unique_tmp_dir(prefix) do
+    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  defp git!(cwd, args) do
+    case System.cmd("git", args, cd: cwd, stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, status} -> flunk("git #{Enum.join(args, " ")} failed (#{status}): #{output}")
+    end
+  end
+
+  test "returns an unavailable context outside a git repository" do
+    cwd = unique_tmp_dir("thinktank-review-context-non-git")
+    context = Context.capture(cwd, %{})
+
+    assert get_in(context, ["git", "available"]) == false
+    assert get_in(context, ["change", "file_count"]) == 0
+  end
+
+  test "captures changed files and signals inside a git repository" do
+    cwd = unique_tmp_dir("thinktank-review-context-git")
+    git!(cwd, ["init"])
+    git!(cwd, ["config", "user.email", "thinktank@example.com"])
+    git!(cwd, ["config", "user.name", "ThinkTank Test"])
+
+    File.mkdir_p!(Path.join(cwd, "lib"))
+    File.write!(Path.join(cwd, "lib/demo.ex"), "defmodule Demo do\n  def run, do: :ok\nend\n")
+    git!(cwd, ["add", "."])
+    git!(cwd, ["commit", "-m", "initial"])
+
+    File.write!(
+      Path.join(cwd, "lib/demo.ex"),
+      "defmodule Demo do\n  def run, do: :updated\nend\n"
+    )
+
+    context = Context.capture(cwd, %{})
+
+    assert get_in(context, ["git", "available"]) == true
+    assert get_in(context, ["change", "file_count"]) >= 1
+    assert get_in(context, ["change", "signals", "touches_code"]) == true
+  end
+end

--- a/test/thinktank/review/eval_test.exs
+++ b/test/thinktank/review/eval_test.exs
@@ -1,0 +1,71 @@
+defmodule Thinktank.Review.EvalTest do
+  use ExUnit.Case, async: false
+
+  alias Thinktank.{Review.Eval, RunContract}
+
+  defp unique_tmp_dir(prefix) do
+    dir = Path.join(System.tmp_dir!(), "#{prefix}-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  test "replays one or more frozen contract files" do
+    workspace = unique_tmp_dir("thinktank-review-eval-workspace")
+    fixture_root = unique_tmp_dir("thinktank-review-eval-fixtures")
+    output_root = Path.join(unique_tmp_dir("thinktank-review-eval-output"), "runs")
+
+    contract = %RunContract{
+      bench_id: "review/cerberus",
+      workspace_root: workspace,
+      input: %{"input_text" => "Review the current change"},
+      artifact_dir: Path.join(fixture_root, "source-run"),
+      adapter_context: %{}
+    }
+
+    first = Path.join([fixture_root, "one", "contract.json"])
+    second = Path.join([fixture_root, "two", "contract.json"])
+    File.mkdir_p!(Path.dirname(first))
+    File.mkdir_p!(Path.dirname(second))
+    File.write!(first, Jason.encode!(RunContract.to_map(contract)))
+    File.write!(second, Jason.encode!(RunContract.to_map(contract)))
+
+    runner = fn _cmd, args, _opts ->
+      prompt =
+        args
+        |> Enum.drop_while(&(&1 != "-p"))
+        |> Enum.at(1)
+        |> String.trim_leading("@")
+        |> File.read!()
+
+      cond do
+        String.contains?(prompt, "Return JSON only with this shape:") ->
+          {Jason.encode!(%{
+             "summary" => "Keep the default bench small.",
+             "selected_agents" => [
+               %{"name" => "trace", "brief" => "Check correctness risks."},
+               %{"name" => "proof", "brief" => "Check coverage gaps."}
+             ],
+             "synthesis_brief" => "Prefer grounded findings."
+           }), 0}
+
+        String.contains?(prompt, "Agent outputs:") ->
+          {"Synthesized summary", 0}
+
+        true ->
+          {"Raw reviewer output", 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Eval.run(fixture_root,
+               output: output_root,
+               bench_id: "review/cerberus",
+               runner: runner
+             )
+
+    assert result.status == "complete"
+    assert length(result.cases) == 2
+    assert Enum.all?(result.cases, &(&1.status == "complete"))
+    assert Enum.all?(result.cases, &File.exists?(Path.join(&1.output_dir, "review/plan.json")))
+  end
+end

--- a/test/thinktank/review/planner_test.exs
+++ b/test/thinktank/review/planner_test.exs
@@ -1,0 +1,59 @@
+defmodule Thinktank.Review.PlannerTest do
+  use ExUnit.Case, async: true
+
+  alias Thinktank.{AgentSpec, Review.Planner}
+
+  defp agent(name) do
+    %AgentSpec{
+      name: name,
+      provider: "openrouter",
+      model: "demo/model",
+      system_prompt: "You are #{name}.",
+      task_prompt: "{{input_text}}"
+    }
+  end
+
+  test "manual planning keeps the bench roster intact" do
+    agents = [agent("trace"), agent("guard"), agent("atlas"), agent("proof")]
+    planning = Planner.manual(agents)
+
+    assert planning.planner_result == nil
+    assert planning.plan["source"] == "manual"
+
+    assert Enum.map(planning.plan["selected_agents"], & &1["name"]) == [
+             "trace",
+             "guard",
+             "atlas",
+             "proof"
+           ]
+  end
+
+  test "render includes selected reviewer names" do
+    agents = [agent("trace"), agent("guard")]
+    planning = Planner.manual(agents)
+    rendered = Planner.render(planning.plan)
+
+    assert rendered =~ "trace"
+    assert rendered =~ "guard"
+  end
+
+  test "applies per-agent reviewer briefs to task prompts" do
+    agents = [agent("trace"), agent("guard")]
+
+    plan = %{
+      "selected_agents" => [
+        %{"name" => "guard", "brief" => "security focus"},
+        %{"name" => "trace", "brief" => "correctness focus"}
+      ]
+    }
+
+    planned = Planner.apply_plan(plan, agents)
+
+    assert Enum.map(planned, & &1.name) == ["guard", "trace"]
+
+    assert Enum.map(planned, &get_in(&1.metadata, ["review_brief"])) == [
+             "security focus",
+             "correctness focus"
+           ]
+  end
+end

--- a/test/thinktank/run_store_test.exs
+++ b/test/thinktank/run_store_test.exs
@@ -61,4 +61,24 @@ defmodule Thinktank.RunStoreTest do
     assert Enum.any?(envelope.agents, &(&1["name"] == "systems"))
     assert Enum.any?(envelope.artifacts, &(&1["name"] == "summary"))
   end
+
+  test "updates manifest with dynamically planned agents" do
+    output_dir = Path.join(unique_tmp_dir("thinktank-run-store-planned"), "run")
+
+    contract = %RunContract{
+      bench_id: "review/cerberus",
+      workspace_root: File.cwd!(),
+      input: %{input_text: "review"},
+      artifact_dir: output_dir,
+      adapter_context: %{}
+    }
+
+    bench = %BenchSpec{id: "review/cerberus", description: "Review", agents: ["trace", "guard"]}
+
+    RunStore.init_run(output_dir, contract, bench)
+    RunStore.set_planned_agents(output_dir, ["trace"])
+
+    manifest = output_dir |> Path.join("manifest.json") |> File.read!() |> Jason.decode!()
+    assert manifest["planned_agents"] == ["trace"]
+  end
 end


### PR DESCRIPTION
## What changed
- expand the built-in review roster with a dedicated `marshal` planner and a new `review/constellation` bench that covers the requested OpenRouter model families
- add a lightweight review context pack and planner step so review benches can pick a focused reviewer subset and pass per-agent briefs without introducing a workflow DSL or hard finding schema
- add `thinktank review eval` to replay frozen `contract.json` workloads through a bench for comparison, plus docs and test coverage for the new review flow

## Why
ThinkTank's review flow was static. This change keeps the harness thin while making review benches more adaptive: factual git-derived context, minimal planner output, free-form reviewer prose, and a simple replay mechanism for bench comparison.

## Impact
- review benches can now compose a smaller, more relevant team per change
- the expanded reviewer bench exposes the additional model families the team wanted to try
- replay evals give a stable way to compare benches on saved review workloads without prematurely baking in noisy scoring

## Validation
- `mix test`
- `mix compile --warnings-as-errors`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `thinktank review eval` CLI command to replay saved review workloads with optional bench override for flexible evaluation.
  * Introduced automated review planning that generates change context and selects appropriate reviewer agents before launching reviews.
  * New review artifacts: context summaries, agent selection plans, and planner output files now generated during review operations.
  * Expanded review agent and bench configurations with new specialized agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->