### PR TITLE
Consolidate review benches, upgrade prompts and agent config

### DIFF
--- a/lib/thinktank/builtin.ex
+++ b/lib/thinktank/builtin.ex
@@ -393,6 +393,9 @@ defmodule Thinktank.Builtin do
     Review plan:
     {{review_plan}}
 
+    Synthesis brief from planner:
+    {{synthesis_brief}}
+
     Agent outputs:
     {{agent_outputs}}
     """

--- a/lib/thinktank/builtin.ex
+++ b/lib/thinktank/builtin.ex
@@ -16,6 +16,7 @@ defmodule Thinktank.Builtin do
         }
       },
       "agents" => %{
+        # ── Research agents (unchanged) ──────────────────────────────
         "systems" =>
           agent(
             "systems",
@@ -49,16 +50,19 @@ defmodule Thinktank.Builtin do
             @research_tools,
             thinking_level: "low"
           ),
+        # ── Review planner ──────────────────────────────────────────
         "marshal" =>
           agent(
             "marshal",
-            "google/gemini-3.1-pro-preview",
+            "openai/gpt-5.4",
             marshal_prompt(),
             review_plan_task_prompt(),
             @review_tools,
             thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "planner"}
           ),
+        # ── Review agents ──────────────────────────────────────────
         "trace" =>
           agent(
             "trace",
@@ -66,6 +70,8 @@ defmodule Thinktank.Builtin do
             trace_prompt(),
             review_task_prompt(),
             @review_tools,
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "correctness"}
           ),
         "guard" =>
@@ -75,16 +81,19 @@ defmodule Thinktank.Builtin do
             guard_prompt(),
             review_task_prompt(),
             @review_tools,
-            thinking_level: "low",
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "security"}
           ),
         "atlas" =>
           agent(
             "atlas",
-            "anthropic/claude-sonnet-4.6",
+            "openai/gpt-5.4-mini",
             atlas_prompt(),
             review_task_prompt(),
             @review_tools,
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "architecture"}
           ),
         "proof" =>
@@ -94,6 +103,8 @@ defmodule Thinktank.Builtin do
             proof_prompt(),
             review_task_prompt(),
             @review_tools,
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "tests"}
           ),
         "vector" =>
@@ -103,6 +114,8 @@ defmodule Thinktank.Builtin do
             vector_prompt(),
             review_task_prompt(),
             @review_tools,
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "interfaces"}
           ),
         "pulse" =>
@@ -112,6 +125,8 @@ defmodule Thinktank.Builtin do
             pulse_prompt(),
             review_task_prompt(),
             @review_tools,
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "runtime-risk"}
           ),
         "scout" =>
@@ -121,7 +136,8 @@ defmodule Thinktank.Builtin do
             scout_prompt(),
             review_task_prompt(),
             @review_tools,
-            thinking_level: "low",
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "integration"}
           ),
         "forge" =>
@@ -131,6 +147,8 @@ defmodule Thinktank.Builtin do
             forge_prompt(),
             review_task_prompt(),
             @review_tools,
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "implementation"}
           ),
         "orbit" =>
@@ -140,6 +158,8 @@ defmodule Thinktank.Builtin do
             orbit_prompt(),
             review_task_prompt(),
             @review_tools,
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "compatibility"}
           ),
         "sentry" =>
@@ -149,8 +169,11 @@ defmodule Thinktank.Builtin do
             sentry_prompt(),
             review_task_prompt(),
             @review_tools,
+            thinking_level: "high",
+            retries: 2,
             metadata: %{"review_role" => "operability"}
           ),
+        # ── Synthesizers ────────────────────────────────────────────
         "research-synth" =>
           agent(
             "research-synth",
@@ -165,7 +188,9 @@ defmodule Thinktank.Builtin do
             "openai/gpt-5.4",
             review_synth_prompt(),
             review_synthesis_task_prompt(),
-            @summary_tools
+            @summary_tools,
+            thinking_level: "high",
+            retries: 2
           )
       },
       "benches" => %{
@@ -177,20 +202,10 @@ defmodule Thinktank.Builtin do
           "synthesizer" => "research-synth",
           "concurrency" => 4
         },
-        "review/cerberus" => %{
+        "review/default" => %{
           "kind" => "review",
           "description" =>
-            "Launch the default review bench: a planner plus a focused team of specialist reviewers.",
-          "agents" => ["trace", "guard", "atlas", "proof", "scout"],
-          "planner" => "marshal",
-          "synthesizer" => "review-synth",
-          "concurrency" => 5,
-          "default_task" => "Review the current change and report only real issues with evidence."
-        },
-        "review/constellation" => %{
-          "kind" => "review",
-          "description" =>
-            "Launch the expanded review roster across model families with a planner and synthesizer.",
+            "Launch the review bench: marshal plans, selects reviewers from the full roster, then synthesizes.",
           "agents" => [
             "trace",
             "guard",
@@ -205,7 +220,7 @@ defmodule Thinktank.Builtin do
           ],
           "planner" => "marshal",
           "synthesizer" => "review-synth",
-          "concurrency" => 8,
+          "concurrency" => 10,
           "default_task" => "Review the current change and report only real issues with evidence."
         }
       }
@@ -230,6 +245,8 @@ defmodule Thinktank.Builtin do
     }
   end
 
+  # ── Research prompts (unchanged) ──────────────────────────────────
+
   defp research_task_prompt do
     """
     {{input_text}}
@@ -243,6 +260,57 @@ defmodule Thinktank.Builtin do
     Report concrete findings, tradeoffs, and recommendations. Cite files and commands when useful.
     """
   end
+
+  defp systems_prompt do
+    """
+    You are a systems architecture researcher. Focus on boundaries, tradeoffs, failure modes,
+    and whether the current design is deeper or shallower than it needs to be.
+    """
+  end
+
+  defp verification_prompt do
+    """
+    You are a verification-minded researcher. Focus on invariants, edge cases, hidden assumptions,
+    and what would have to be true for the current approach to be safe.
+    """
+  end
+
+  defp ml_prompt do
+    """
+    You are an AI systems researcher. Focus on where the harness is compensating for weak models,
+    where stronger models change the tradeoffs, and where native agent behavior should own the work.
+    """
+  end
+
+  defp dx_prompt do
+    """
+    You are a developer experience reviewer. Focus on how easy this system is to extend, operate,
+    debug, and understand without cargo-culting its internals.
+    """
+  end
+
+  defp research_synth_prompt do
+    """
+    You synthesize multiple research agent reports into one concise document.
+    Preserve disagreements. Do not invent consensus. Favor grounded recommendations over rhetoric.
+    """
+  end
+
+  defp research_synthesis_task_prompt do
+    """
+    Original task:
+    {{input_text}}
+
+    Workspace root: {{workspace_root}}
+    Focus paths:
+    {{paths_hint}}
+
+    Agent outputs:
+    {{agent_outputs}}
+    """
+  end
+
+  # ── Review task prompts ───────────────────────────────────────────
 
   defp review_task_prompt do
     """
@@ -306,20 +374,6 @@ defmodule Thinktank.Builtin do
     """
   end
 
-  defp research_synthesis_task_prompt do
-    """
-    Original task:
-    {{input_text}}
-
-    Workspace root: {{workspace_root}}
-    Focus paths:
-    {{paths_hint}}
-
-    Agent outputs:
-    {{agent_outputs}}
-    """
-  end
-
   defp review_synthesis_task_prompt do
     """
     Original task:
@@ -344,125 +398,221 @@ defmodule Thinktank.Builtin do
     """
   end
 
-  defp systems_prompt do
-    """
-    You are a systems architecture researcher. Focus on boundaries, tradeoffs, failure modes,
-    and whether the current design is deeper or shallower than it needs to be.
-    """
-  end
-
-  defp verification_prompt do
-    """
-    You are a verification-minded researcher. Focus on invariants, edge cases, hidden assumptions,
-    and what would have to be true for the current approach to be safe.
-    """
-  end
-
-  defp ml_prompt do
-    """
-    You are an AI systems researcher. Focus on where the harness is compensating for weak models,
-    where stronger models change the tradeoffs, and where native agent behavior should own the work.
-    """
-  end
-
-  defp dx_prompt do
-    """
-    You are a developer experience reviewer. Focus on how easy this system is to extend, operate,
-    debug, and understand without cargo-culting its internals.
-    """
-  end
+  # ── Review system prompts ─────────────────────────────────────────
 
   defp marshal_prompt do
     """
-    You are marshal, the review planner. Build a concise plan for this change:
-    likely risk zones, where reviewers should focus, and what evidence would confirm risk.
-    Do not claim defects unless you can ground them directly in inspected code. Prefer a small, relevant
-    team over exhaustive fan-out.
+    You are marshal, the review planner. Your job is to read the change, assess
+    its risk profile, and assemble the right review team from the available roster.
+
+    Inspect the diff, changed files, and surrounding code. Identify what the change
+    is actually doing — not just what files were touched. Determine where risk
+    concentrates: correctness, security, architecture, tests, integration, interfaces,
+    runtime behavior, implementation quality, compatibility, or operability.
+
+    Prefer a focused team over exhaustive coverage. A narrow bug fix needs two or three
+    reviewers, not ten. A sweeping refactor across module boundaries might need most of
+    them. Write each selected reviewer a brief that tells them exactly where to look
+    and what to worry about — the brief is their primary steering signal.
+
+    Do not report findings yourself. Your output is a plan, not a review.
     """
   end
 
   defp trace_prompt do
     """
-    You are trace, a correctness reviewer. Hunt for behavioral regressions, broken assumptions,
-    and control-flow mistakes. Ignore style-only nits.
+    You are trace, a correctness reviewer. Your job is to find bugs, behavioral
+    regressions, and broken assumptions in the change.
+
+    Trace execution paths through the changed code. Verify that control flow handles
+    all reachable states, that edge cases and boundary conditions are covered, and that
+    assumptions made by the code match the actual behavior of called functions and APIs.
+    Check that the change does what it claims to do, not just what it appears to do.
+
+    Read the surrounding code, not just the diff. Bugs often hide at the boundary
+    between changed and unchanged code. Use git diff, grep, and file reads to ground
+    your findings in evidence.
+
+    Report both line-specific issues and general observations about the change's
+    correctness. Ignore style-only nits.
     """
   end
 
   defp guard_prompt do
     """
-    You are guard, a security reviewer. Look for trust-boundary bugs, auth flaws, injection risk,
-    and unsafe defaults. Report only issues grounded in real code paths.
+    You are guard, a security reviewer. Your job is to find security vulnerabilities,
+    trust-boundary violations, and unsafe defaults in the change.
+
+    Focus on input validation and sanitization at system boundaries, authentication
+    and authorization logic, injection vectors (SQL, command, XSS, path traversal),
+    credential and secret handling, trust boundaries between components and external
+    services, and unsafe defaults that could be exploited.
+
+    Trace data flow from untrusted sources through the changed code. Check what an
+    adversary could do with unexpected input. Read the surrounding code to understand
+    the full trust model.
+
+    Report both specific vulnerabilities with evidence and broader security concerns
+    about the change's design. Not every change has security issues — if you find
+    none, say so plainly.
     """
   end
 
   defp atlas_prompt do
     """
-    You are atlas, an architecture reviewer. Focus on coupling, module depth, interface clarity,
-    and whether the change makes future work harder than it needs to be.
+    You are atlas, an architecture reviewer. Your job is to evaluate whether the
+    change makes the codebase better or worse to work in long-term.
+
+    Focus on module boundaries and coupling — does this change respect existing
+    boundaries or erode them? Evaluate interface depth: are modules deep (simple
+    interface, rich functionality) or shallow (pass-through, thin wrappers)? Check
+    information hiding: does the change expose implementation details that should be
+    private? Assess design coherence: does the change fit the existing architecture
+    or introduce a conflicting pattern?
+
+    Read the module structure, public APIs, and how the changed code connects to
+    the rest of the system. Architecture issues often cannot be linked to a single
+    line — general observations about design direction are valuable.
+
+    Do not nitpick naming or formatting. Focus on structural decisions that compound
+    over time.
     """
   end
 
   defp proof_prompt do
     """
-    You are proof, a testing reviewer. Focus on concrete regression risk, brittle tests,
-    and behavior that remains unverified.
+    You are proof, a testing reviewer. Your job is to evaluate whether the change
+    is adequately tested and whether existing tests remain trustworthy.
+
+    Focus on whether the important behaviors introduced or changed by this diff are
+    covered by tests, whether tests verify behavior (what the code does) rather than
+    implementation (how it does it), whether there are brittle tests that will break
+    on unrelated changes, and whether there is regression risk from untested paths.
+
+    Run the test suite if practical. Read test files alongside the code they test.
+    Check that test assertions match the actual contract being tested, not just the
+    current output.
+
+    If the change is well-tested, say so. If tests are missing, identify which
+    behaviors need coverage and why.
     """
   end
 
   defp vector_prompt do
     """
-    You are vector, an API and interface reviewer. Focus on boundary contracts, caller impact,
-    and mismatches between module intent and exposed behavior.
+    You are vector, an API and interface reviewer. Your job is to evaluate the
+    public-facing contracts introduced or changed by this diff.
+
+    Focus on whether API changes are backward-compatible or break existing callers,
+    whether function signatures, return types, and error contracts match their
+    documentation and usage, whether the interface is minimal and coherent or leaks
+    implementation details, and whether there are mismatches between what a module
+    promises and what it delivers.
+
+    Trace callers and consumers of changed interfaces. Check that every caller
+    handles the new contract correctly. Interface issues compound — a bad API today
+    means workarounds forever.
     """
   end
 
   defp pulse_prompt do
     """
-    You are pulse, a runtime-risk reviewer. Focus on latency spikes, concurrency hazards,
-    resource leaks, and any behavior that can fail under production load.
+    You are pulse, a runtime-risk reviewer. Your job is to find issues that will
+    only manifest under real-world load and concurrency.
+
+    Focus on race conditions and concurrency hazards, resource leaks (file handles,
+    connections, memory), latency-sensitive paths that could degrade under load,
+    error handling under partial failure (network timeouts, service unavailability),
+    and unbounded growth (queues, caches, logs).
+
+    Read the code with production conditions in mind. What happens when this runs
+    for days? What happens when upstream is slow? What happens under 10x normal load?
+
+    Not every change has runtime risk. If the change is straightforward, say so.
     """
   end
 
   defp scout_prompt do
     """
-    You are scout, an integration reviewer. Focus on how this change interacts with adjacent
-    modules, external services, and deployment expectations.
+    You are scout, an integration reviewer. Your job is to find issues at the
+    boundaries where this change meets the rest of the system.
+
+    Focus on how the changed code interacts with adjacent modules, external services,
+    and data stores. Check whether API contracts (function signatures, message formats,
+    database schemas) are honored. Look at deployment and configuration implications.
+    Evaluate whether the change introduces assumptions about execution environment
+    that may not hold.
+
+    Read beyond the diff to understand the integration surface. Check callers,
+    configuration files, and deployment manifests. Integration bugs often appear
+    only when components are combined.
+
+    Report both specific contract violations and general concerns about how this
+    change fits into the broader system.
     """
   end
 
   defp forge_prompt do
     """
-    You are forge, an implementation reviewer. Focus on hidden complexity, brittle control flow,
-    and whether the change is harder to operate than necessary.
+    You are forge, an implementation reviewer. Your job is to evaluate the craft
+    of the code itself — whether it is clear, maintainable, and honest about its
+    complexity.
+
+    Focus on hidden complexity (is the code harder to understand than the problem
+    warrants?), brittle control flow (deeply nested conditionals, implicit state
+    machines, action-at-a-distance), readability (will the next person understand
+    this without the PR description?), and operational burden (is this code easy to
+    debug when it breaks at 3am?).
+
+    Read the implementation with fresh eyes. The question is not whether it works,
+    but whether it will continue to work as the codebase evolves. General observations
+    about code quality are as valuable as specific line-level findings.
     """
   end
 
   defp orbit_prompt do
     """
-    You are orbit, a compatibility reviewer. Focus on upgrade paths, backward compatibility,
-    and behavior differences across expected execution environments.
+    You are orbit, a compatibility reviewer. Your job is to find issues with upgrade
+    paths, backward compatibility, and cross-environment behavior.
+
+    Focus on whether the change breaks existing consumers, configurations, or data
+    formats. Check for migration paths when breaking changes are introduced. Look at
+    whether the code assumes a specific runtime version, OS, or environment. Check for
+    serialization or persistence format changes that affect existing data.
+
+    Check version constraints, configuration schemas, and data format expectations.
+    Compatibility issues are often invisible in tests but catastrophic in production.
     """
   end
 
   defp sentry_prompt do
     """
-    You are sentry, an operability reviewer. Focus on failure visibility, logging and diagnostics,
-    and whether this change is supportable when incidents happen.
-    """
-  end
+    You are sentry, an operability reviewer. Your job is to evaluate whether this
+    change is supportable when things go wrong in production.
 
-  defp research_synth_prompt do
-    """
-    You synthesize multiple research agent reports into one concise document.
-    Preserve disagreements. Do not invent consensus. Favor grounded recommendations over rhetoric.
+    Focus on failure visibility (will operators know when this code fails? are errors
+    logged with enough context?), diagnostics (can someone debug a problem without
+    reading the source?), graceful degradation (does the system handle partial failures
+    without cascading?), and monitoring (are important state changes observable?).
+
+    Read the code from an operator's perspective. The question is not whether it
+    works, but whether you can tell when it stops working.
+
+    If the change is internal plumbing with no operational surface, say so.
     """
   end
 
   defp review_synth_prompt do
     """
-    You synthesize multiple code review reports into one concise review summary.
-    Preserve reviewer attribution. If the bench found no real issues, say that plainly.
-    Do not force structured JSON. Write a clear human review.
+    You synthesize multiple code review reports into one actionable review document.
+
+    Deduplicate: when multiple reviewers flag the same issue, consolidate into one
+    finding and credit all reviewers who caught it. Prioritize by severity and impact,
+    not by reviewer order. Preserve genuine disagreements — if reviewers contradict
+    each other, present both positions rather than picking a winner.
+
+    If the bench found no real issues, say that plainly. Do not manufacture concerns
+    to fill space. Write a clear human review, not structured JSON.
     """
   end
 end

--- a/lib/thinktank/cli.ex
+++ b/lib/thinktank/cli.ex
@@ -245,7 +245,7 @@ defmodule Thinktank.CLI do
   defp build_command(["review", "eval"], _parsed), do: {:error, "review eval requires a path"}
 
   defp build_command(["review" | remainder], parsed) do
-    with {:ok, config, bench} <- resolve_bench("review/cerberus", parsed),
+    with {:ok, config, bench} <- resolve_bench("review/default", parsed),
          :ok <- validate_review_pr_flags(bench, parsed) do
       input_text = resolve_input_text(parsed[:input], remainder)
 
@@ -595,8 +595,8 @@ defmodule Thinktank.CLI do
     Examples:
       thinktank research "analyze this codebase" --paths ./lib
       thinktank review --base origin/main --head HEAD
-      thinktank review eval ./tmp/review-run --bench review/constellation
-      thinktank run review/cerberus --input "Review this branch" --agents trace,guard
+      thinktank review eval ./tmp/review-run --bench review/default
+      thinktank run review/default --input "Review this branch" --agents trace,guard
       thinktank benches show research/default
     """
   end

--- a/lib/thinktank/engine.ex
+++ b/lib/thinktank/engine.ex
@@ -302,7 +302,8 @@ defmodule Thinktank.Engine do
     context = %{
       "paths_hint" => render_paths_hint(contract.input),
       "review_context" => Context.render(review_context),
-      "review_plan" => Planner.render(planning.plan)
+      "review_plan" => Planner.render(planning.plan),
+      "synthesis_brief" => planning.plan["synthesis_brief"] || ""
     }
 
     {planned_agents, context}

--- a/lib/thinktank/executor/agentic.ex
+++ b/lib/thinktank/executor/agentic.ex
@@ -95,7 +95,8 @@ defmodule Thinktank.Executor.Agentic do
 
     prompt = "#{agent.system_prompt}\n\n#{rendered_prompt}"
     prompt_file = write_prompt_file(contract, instance_id, prompt)
-    {cmd, args} = build_command(agent, prompt_file, tool_list(agent))
+    provider = config.providers[agent.provider]
+    {cmd, args} = build_command(agent, prompt_file, tool_list(agent), provider)
 
     cmd_opts =
       build_cmd_opts(agent, instance_id, contract, config.providers[agent.provider], opts)
@@ -165,7 +166,7 @@ defmodule Thinktank.Executor.Agentic do
   defp retryable?(%{category: :crash}), do: true
   defp retryable?(_), do: false
 
-  defp build_command(agent, prompt_file, tools) do
+  defp build_command(agent, prompt_file, tools, provider) do
     {"sh",
      [
        "-c",
@@ -174,6 +175,8 @@ defmodule Thinktank.Executor.Agentic do
        "pi",
        "--no-session",
        "--no-skills",
+       "--provider",
+       to_string(provider.adapter),
        "--model",
        agent.model,
        "--thinking",

--- a/lib/thinktank/review/eval.ex
+++ b/lib/thinktank/review/eval.ex
@@ -34,7 +34,7 @@ defmodule Thinktank.Review.Eval do
   end
 
   defp run_case(index, contract_path, contract, output_dir, opts) do
-    bench_id = Keyword.get(opts, :bench_id, contract.bench_id)
+    bench_id = Keyword.get(opts, :bench_id) || "review/default"
     case_id = "case-#{String.pad_leading(Integer.to_string(index), 3, "0")}"
     case_output = Path.join(output_dir, case_id)
 

--- a/test/thinktank/bench_spec_test.exs
+++ b/test/thinktank/bench_spec_test.exs
@@ -5,7 +5,7 @@ defmodule Thinktank.BenchSpecTest do
 
   test "parses bench specs" do
     assert {:ok, bench} =
-             BenchSpec.from_pair("review/cerberus", %{
+             BenchSpec.from_pair("review/default", %{
                "kind" => "review",
                "description" => "Review bench",
                "agents" => ["trace", "guard"],
@@ -15,7 +15,7 @@ defmodule Thinktank.BenchSpecTest do
                "default_task" => "Review this"
              })
 
-    assert bench.id == "review/cerberus"
+    assert bench.id == "review/default"
     assert bench.kind == :review
     assert bench.agents == ["trace", "guard"]
     assert bench.planner == "marshal"
@@ -34,7 +34,7 @@ defmodule Thinktank.BenchSpecTest do
           {%{"description" => "Review bench", "agents" => ["trace"], "default_task" => "   "},
            "bench optional string fields must be strings"}
         ] do
-      assert {:error, ^expected_error} = BenchSpec.from_pair("review/cerberus", raw)
+      assert {:error, ^expected_error} = BenchSpec.from_pair("review/default", raw)
     end
   end
 end

--- a/test/thinktank/cli_test.exs
+++ b/test/thinktank/cli_test.exs
@@ -60,7 +60,7 @@ defmodule Thinktank.CLITest do
                "42"
              ])
 
-    assert command.bench_id == "review/cerberus"
+    assert command.bench_id == "review/default"
     assert command.input.base == "origin/main"
     assert command.input.head == "HEAD"
     assert command.input.repo == "misty-step/thinktank"
@@ -74,18 +74,18 @@ defmodule Thinktank.CLITest do
                "eval",
                "./tmp/review-run",
                "--bench",
-               "review/constellation",
+               "review/default",
                "--json"
              ])
 
     assert command.action == :review_eval
     assert command.target == Path.expand("./tmp/review-run")
-    assert command.bench_id == "review/constellation"
+    assert command.bench_id == "review/default"
     assert command.json == true
   end
 
   test "requires --repo when --pr is provided for review" do
-    assert {:error, "review/cerberus requires --repo when --pr is provided"} =
+    assert {:error, "review/default requires --repo when --pr is provided"} =
              CLI.parse_args(["review", "--pr", "42"])
   end
 
@@ -195,8 +195,8 @@ defmodule Thinktank.CLITest do
     assert {:ok, %{action: :benches_list}} = CLI.parse_args(["benches", "list"])
     assert {:ok, %{action: :benches_validate}} = CLI.parse_args(["workflows", "validate"])
 
-    assert {:ok, %{action: :benches_show, bench_id: "review/cerberus"}} =
-             CLI.parse_args(["workflows", "show", "review/cerberus"])
+    assert {:ok, %{action: :benches_show, bench_id: "review/default"}} =
+             CLI.parse_args(["workflows", "show", "review/default"])
   end
 
   test "returns :needs_stdin when no research input is provided" do
@@ -278,7 +278,7 @@ defmodule Thinktank.CLITest do
       end)
 
     assert {:ok, decoded} = Jason.decode(String.trim(output))
-    assert decoded["bench"] == "review/cerberus"
+    assert decoded["bench"] == "review/default"
     assert decoded["planner"] == "marshal"
   end
 

--- a/test/thinktank/config_test.exs
+++ b/test/thinktank/config_test.exs
@@ -17,13 +17,12 @@ defmodule Thinktank.ConfigTest do
 
     assert Map.has_key?(config.providers, "openrouter")
     assert Map.has_key?(config.benches, "research/default")
-    assert Map.has_key?(config.benches, "review/cerberus")
-    assert Map.has_key?(config.benches, "review/constellation")
+    assert Map.has_key?(config.benches, "review/default")
     assert Map.has_key?(config.agents, "marshal")
     assert Map.has_key?(config.agents, "trace")
     assert config.benches["research/default"].kind == :research
-    assert config.benches["review/cerberus"].kind == :review
-    assert config.benches["review/cerberus"].planner == "marshal"
+    assert config.benches["review/default"].kind == :review
+    assert config.benches["review/default"].planner == "marshal"
   end
 
   test "repo config overrides user config and adds benches when trusted" do

--- a/test/thinktank/engine_test.exs
+++ b/test/thinktank/engine_test.exs
@@ -59,7 +59,7 @@ defmodule Thinktank.EngineTest do
 
     assert {:ok, result} =
              Engine.run(
-               "review/cerberus",
+               "review/default",
                %{
                  input_text: "Review this branch",
                  base: "origin/main",
@@ -97,7 +97,7 @@ defmodule Thinktank.EngineTest do
 
     assert {:ok, result} =
              Engine.run(
-               "review/cerberus",
+               "review/default",
                %{input_text: "Review this branch"},
                cwd: cwd,
                runner: runner
@@ -222,7 +222,7 @@ defmodule Thinktank.EngineTest do
 
     assert {:ok, result} =
              Engine.run(
-               "review/cerberus",
+               "review/default",
                %{input_text: "Review this branch", no_synthesis: true},
                cwd: cwd,
                runner: runner
@@ -264,7 +264,7 @@ defmodule Thinktank.EngineTest do
 
     assert {:ok, result} =
              Engine.run(
-               "review/cerberus",
+               "review/default",
                %{input_text: "Review this branch", agents: ["guard"], no_synthesis: true},
                cwd: cwd,
                runner: runner

--- a/test/thinktank/executor/agentic_test.exs
+++ b/test/thinktank/executor/agentic_test.exs
@@ -29,7 +29,7 @@ defmodule Thinktank.Executor.AgenticTest do
 
   defp contract(tmp) do
     %RunContract{
-      bench_id: "review/cerberus",
+      bench_id: "review/default",
       workspace_root: tmp,
       input: %{"input_text" => "Review this"},
       artifact_dir: Path.join(tmp, "out"),

--- a/test/thinktank/review/eval_test.exs
+++ b/test/thinktank/review/eval_test.exs
@@ -15,7 +15,7 @@ defmodule Thinktank.Review.EvalTest do
     output_root = Path.join(unique_tmp_dir("thinktank-review-eval-output"), "runs")
 
     contract = %RunContract{
-      bench_id: "review/cerberus",
+      bench_id: "review/default",
       workspace_root: workspace,
       input: %{"input_text" => "Review the current change"},
       artifact_dir: Path.join(fixture_root, "source-run"),
@@ -59,7 +59,7 @@ defmodule Thinktank.Review.EvalTest do
     assert {:ok, result} =
              Eval.run(fixture_root,
                output: output_root,
-               bench_id: "review/cerberus",
+               bench_id: "review/default",
                runner: runner
              )
 

--- a/test/thinktank/review/eval_test.exs
+++ b/test/thinktank/review/eval_test.exs
@@ -68,4 +68,57 @@ defmodule Thinktank.Review.EvalTest do
     assert Enum.all?(result.cases, &(&1.status == "complete"))
     assert Enum.all?(result.cases, &File.exists?(Path.join(&1.output_dir, "review/plan.json")))
   end
+
+  test "replays a historical contract with a removed bench_id through review/default" do
+    workspace = unique_tmp_dir("thinktank-review-eval-historical")
+    fixture_root = unique_tmp_dir("thinktank-review-eval-historical-fixtures")
+    output_root = Path.join(unique_tmp_dir("thinktank-review-eval-historical-output"), "runs")
+
+    contract = %RunContract{
+      bench_id: "review/cerberus",
+      workspace_root: workspace,
+      input: %{"input_text" => "Review the current change"},
+      artifact_dir: Path.join(fixture_root, "source-run"),
+      adapter_context: %{}
+    }
+
+    path = Path.join([fixture_root, "historical", "contract.json"])
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, Jason.encode!(RunContract.to_map(contract)))
+
+    runner = fn _cmd, args, _opts ->
+      prompt =
+        args
+        |> Enum.drop_while(&(&1 != "-p"))
+        |> Enum.at(1)
+        |> String.trim_leading("@")
+        |> File.read!()
+
+      cond do
+        String.contains?(prompt, "Return JSON only with this shape:") ->
+          {Jason.encode!(%{
+             "summary" => "Historical replay.",
+             "selected_agents" => [
+               %{"name" => "trace", "brief" => "Check regressions."}
+             ],
+             "synthesis_brief" => "Consolidate findings."
+           }), 0}
+
+        String.contains?(prompt, "Agent outputs:") ->
+          {"Synthesized", 0}
+
+        true ->
+          {"ok", 0}
+      end
+    end
+
+    assert {:ok, result} =
+             Eval.run(fixture_root,
+               output: output_root,
+               runner: runner
+             )
+
+    assert result.status == "complete"
+    assert Enum.all?(result.cases, &(&1.bench == "review/default"))
+  end
 end

--- a/test/thinktank/run_store_test.exs
+++ b/test/thinktank/run_store_test.exs
@@ -66,14 +66,14 @@ defmodule Thinktank.RunStoreTest do
     output_dir = Path.join(unique_tmp_dir("thinktank-run-store-planned"), "run")
 
     contract = %RunContract{
-      bench_id: "review/cerberus",
+      bench_id: "review/default",
       workspace_root: File.cwd!(),
       input: %{input_text: "review"},
       artifact_dir: output_dir,
       adapter_context: %{}
     }
 
-    bench = %BenchSpec{id: "review/cerberus", description: "Review", agents: ["trace", "guard"]}
+    bench = %BenchSpec{id: "review/default", description: "Review", agents: ["trace", "guard"]}
 
     RunStore.init_run(output_dir, contract, bench)
     RunStore.set_planned_agents(output_dir, ["trace"])


### PR DESCRIPTION
## Summary
- Merge `review/cerberus` and `review/constellation` into a single `review/default` bench — marshal selects from the full 10-agent roster per change
- Upgrade marshal and review-synth to GPT-5.4; move atlas off Sonnet 4.6 to GPT-5.4-mini
- Set all review agents to `thinking_level: "high"` and `retries: 2`
- Rewrite all reviewer system prompts with substantive role guidance

## Test plan
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 65 tests, 0 failures
- [ ] Run the new review flow against this PR to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry mechanisms and enhanced thinking capabilities to review agents.
  * Expanded review prompt configurations with additional helper functions.

* **Bug Fixes / Improvements**
  * Increased review operation concurrency for better performance.
  * Consolidated review benchmarks into a single unified configuration.

* **Chores**
  * Updated agent model configurations across the review system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->