### PR TITLE
refactor(config): delete dead workflow aliases

### DIFF
--- a/.groom/review-scores.ndjson
+++ b/.groom/review-scores.ndjson
@@ -1,0 +1,1 @@
+{"date":"2026-04-01","pr":null,"correctness":9,"depth":8,"simplicity":10,"craft":9,"verdict":"ship"}

--- a/backlog.d/003-delete-dead-workflow-api.md
+++ b/backlog.d/003-delete-dead-workflow-api.md
@@ -1,7 +1,7 @@
 # Delete Dead Workflow API
 
 Priority: low
-Status: ready
+Status: in-progress
 Estimate: S
 
 ## Goal

--- a/backlog.d/003-delete-dead-workflow-api.md
+++ b/backlog.d/003-delete-dead-workflow-api.md
@@ -1,7 +1,7 @@
 # Delete Dead Workflow API
 
 Priority: low
-Status: in-progress
+Status: done
 Estimate: S
 
 ## Goal
@@ -11,10 +11,15 @@ Remove unreferenced `Config.workflow/2` and `Config.list_workflows/1` — legacy
 - Refactoring Config module beyond deletion
 
 ## Oracle
-- [ ] `Config.workflow/2` and `Config.list_workflows/1` do not exist
-- [ ] `mix compile --warnings-as-errors` clean
-- [ ] `mix test` passes
-- [ ] No references to "workflow" remain in Config module
+- [x] `Config.workflow/2` and `Config.list_workflows/1` do not exist
+- [x] `mix compile --warnings-as-errors` clean
+- [x] `mix test` passes
+- [x] No references to "workflow" remain in Config module
+
+## What Was Built
+- Deleted the dead `workflow/2` and `list_workflows/1` aliases from `Thinktank.Config`, leaving `bench/2` and `list_benches/1` as the only public lookup surface.
+- Added a focused regression test that asserts the bench APIs remain exported while the legacy workflow aliases do not.
+- Verified there are no remaining `Config.workflow(...)` or `Config.list_workflows(...)` call sites under `lib/` or `test/`.
 
 ## Notes
 Archaeologist flagged these as dead code — public functions with zero callers or tests. Leftover from a "workflows" → "benches" rename.

--- a/lib/thinktank/config.ex
+++ b/lib/thinktank/config.ex
@@ -48,12 +48,6 @@ defmodule Thinktank.Config do
     benches |> Map.values() |> Enum.sort_by(& &1.id)
   end
 
-  @spec workflow(t(), String.t()) :: {:ok, BenchSpec.t()} | {:error, String.t()}
-  def workflow(config, id), do: bench(config, id)
-
-  @spec list_workflows(t()) :: [BenchSpec.t()]
-  def list_workflows(config), do: list_benches(config)
-
   @spec user_config_dir(keyword()) :: String.t()
   def user_config_dir(opts \\ []) do
     home = Keyword.get(opts, :user_home, System.user_home!())

--- a/test/thinktank/config_test.exs
+++ b/test/thinktank/config_test.exs
@@ -98,4 +98,11 @@ defmodule Thinktank.ConfigTest do
     assert {:error, "bench demo/invalid: bench references unknown agent ghost"} =
              Config.load(cwd: tmp, trust_repo_config: true)
   end
+
+  test "does not expose legacy workflow aliases" do
+    assert function_exported?(Config, :bench, 2)
+    assert function_exported?(Config, :list_benches, 1)
+    refute function_exported?(Config, :workflow, 2)
+    refute function_exported?(Config, :list_workflows, 1)
+  end
 end


### PR DESCRIPTION
## Summary
- delete the dead `Thinktank.Config.workflow/2` and `Thinktank.Config.list_workflows/1` aliases
- add a focused regression test that preserves `bench/2` and `list_benches/1` while asserting the legacy aliases are gone
- close backlog item `backlog.d/003-delete-dead-workflow-api.md` and record the review verdict in `.groom/review-scores.ndjson`

## Validation
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test test/thinktank/config_test.exs`
- `mix test`
- `rg -n "Config\\.(workflow|list_workflows)\\(" lib test` returns no matches

## QA
- skipped: pure internal refactor, no user-facing surface

## Evidence
- red: targeted config test failed while `workflow/2` was still exported
- green: targeted config test and full test suite passed after removing the aliases

## Review
- parallel review bench verdict: ship

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completed task documenting the removal of legacy workflow API functions and verification that the public interface conforms to current standards.

* **Refactor**
  * Removed legacy workflow API functions; equivalent functionality is available through the bench API.

* **Tests**
  * Added regression test to verify API surface constraints, confirming `bench/2` and `list_benches/1` remain exported while legacy workflow functions are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->